### PR TITLE
Fix return code which is an error occurred at pthread function

### DIFF
--- a/lib/log_thread.c
+++ b/lib/log_thread.c
@@ -135,7 +135,7 @@ qb_log_thread_priority_set(int32_t policy, int32_t priority)
 		res = pthread_setschedparam(logt_thread_id, policy,
 					    &logt_sched_param);
 		if (res != 0) {
-			res = -errno;
+			res = -res;
 		}
 	}
 #endif
@@ -158,7 +158,7 @@ qb_log_thread_start(void)
 			     qb_logt_worker_thread, NULL);
 	if (res != 0) {
 		wthread_active = 0;
-		return -errno;
+		return -res;
 	}
 	sem_wait(&logt_thread_start);
 


### PR DESCRIPTION
The processing which is referring to the errno variable as a processing result of a pthread function was corrected. 
