### PR TITLE
Add the processing which remove notifier at skiplist_destroy function

### DIFF
--- a/lib/skiplist.c
+++ b/lib/skiplist.c
@@ -221,9 +221,19 @@ skiplist_notify(struct skiplist *l, struct skiplist_node *n,
 static void
 skiplist_node_destroy(struct skiplist_node *node, struct skiplist *list)
 {
+	struct qb_list_head *pos;
+	struct qb_list_head *next;
+	struct qb_map_notifier *tn;
+
 	skiplist_notify(list, node,
 			QB_MAP_NOTIFY_DELETED,
 			(char *)node->key, node->value, NULL);
+
+	qb_list_for_each_safe(pos, next, &node->notifier_head) {
+		tn = qb_list_entry(pos, struct qb_map_notifier, list);
+		qb_list_del(&tn->list);
+		free(tn);
+	}
 
 	free(node->forward);
 	free(node);


### PR DESCRIPTION
The skiplist_destroy function had removed the skiplist node.
The process of removing the notifier was added at skiplist_destroy function.
In addition, processing of the hashtable_destroy function was unified with other processings.

I have read the quarterback-devel Digest, Vol 33, Issue 9.
There is no pending patch. :-)
