### PR TITLE
Add an IPC server service context

### DIFF
--- a/include/qb/qbipcs.h
+++ b/include/qb/qbipcs.h
@@ -195,6 +195,25 @@ void qb_ipcs_poll_handlers_set(qb_ipcs_service_t* s,
 	struct qb_ipcs_poll_handlers *handlers);
 
 /**
+ * Associate a "user" pointer with this service.
+ *
+ * @param s service instance
+ * @param context the pointer to associate with this service.
+ * @see qb_ipcs_service_context_get()
+ */
+void qb_ipcs_service_context_set(qb_ipcs_service_t* s,
+	void *context);
+
+/**
+ * Get the context (set previously)
+ *
+ * @param s service instance
+ * @return the context
+ * @see qb_ipcs_service_context_set()
+ */
+void *qb_ipcs_service_context_get(qb_ipcs_service_t* s);
+
+/**
  * run the new IPC server.
  * @param s service instance
  * @return 0 == ok; -errno to indicate a failure
@@ -320,6 +339,15 @@ void qb_ipcs_context_set(qb_ipcs_connection_t *c, void *context);
  * @see qb_ipcs_context_set()
  */
 void *qb_ipcs_context_get(qb_ipcs_connection_t *c);
+
+/**
+ * Get the context previously set on the service backing this connection
+ *
+ * @param c connection instance
+ * @return the context
+ * @see qb_ipcs_service_context_set
+ */
+void *qb_ipcs_connection_service_context_get(qb_ipcs_connection_t *c);
 
 /**
  * Get the connection statistics.

--- a/lib/ipc_int.h
+++ b/lib/ipc_int.h
@@ -147,6 +147,8 @@ struct qb_ipcs_service {
 	struct qb_list_head connections;
 	struct qb_list_head list;
 	struct qb_ipcs_stats stats;
+
+	void *context;
 };
 
 enum qb_ipcs_connection_state {

--- a/lib/ipcs.c
+++ b/lib/ipcs.c
@@ -85,6 +85,19 @@ qb_ipcs_poll_handlers_set(struct qb_ipcs_service *s,
 	s->poll_fns.dispatch_del = handlers->dispatch_del;
 }
 
+void
+qb_ipcs_service_context_set(qb_ipcs_service_t* s,
+			    void *context)
+{
+	s->context = context;
+}
+
+void *
+qb_ipcs_service_context_get(qb_ipcs_service_t* s)
+{
+	return s->context;
+}
+
 int32_t
 qb_ipcs_run(struct qb_ipcs_service *s)
 {
@@ -813,6 +826,15 @@ qb_ipcs_context_get(struct qb_ipcs_connection *c)
 		return NULL;
 	}
 	return c->context;
+}
+
+void *
+qb_ipcs_connection_service_context_get(qb_ipcs_connection_t *c)
+{
+	if (c == NULL || c->service == NULL) {
+		return NULL;
+	}
+	return c->service->context;
 }
 
 int32_t


### PR DESCRIPTION
Add a context pointer to the IPC server service object.  Add a setter and getter for accessing this from the service, and add a getter for retrieving this from the connection.

This helps me to avoid globals when using libqb with some light C++ abstractions.
