### PR TITLE
Use a system-supplied maximum number of signals on Mac OS X.

### DIFF
--- a/lib/loop_poll.c
+++ b/lib/loop_poll.c
@@ -26,6 +26,12 @@
 
 #include <signal.h>
 
+#if defined(__DARWIN_NSIG)
+#define QB_MAX_NUM_SIGNALS __DARWIN_NSIG
+#else
+#define QB_MAX_NUM_SIGNALS 30
+#endif
+
 #include "loop_poll_int.h"
 
 /*
@@ -620,7 +626,7 @@ _adjust_sigactions_(struct qb_signal_source *s)
 	sigemptyset(&sa.sa_mask);
 
 	/* re-set to default */
-	for (i = 0; i < 30; i++) {
+	for (i = 0; i < QB_MAX_NUM_SIGNALS; i++) {
 		needed = QB_FALSE;
 		qb_list_for_each_entry(item, &s->sig_head, list) {
 			sig = (struct qb_loop_sig *)item;


### PR DESCRIPTION
On Mac OS X the maximum number of signals is 31, with SIGUSR2 being number 31.  Due to the loop in _adjust_sigactions_ only going up to 30, SIGUSR1 and SIGUSR2 cannot be caught and processed by libqb.

 This gets change gets SIGUSR1 (#30) and SIGUSR2 (#31) working for my application.

Note that I'm using the presence of a Darwin specific define (__DARWIN_NSIG), which is always present on Darwin.  As far as I know, the more general NSIG macro should be available if _POSIX_C_SOURCE (any version) is defined when libqb is compiled.  This would address this issue in a completely portable fashion.
