### PR TITLE
Fix sockaddr_un.sun_path overflow on Mac OS X 10.9

### DIFF
--- a/lib/ipc_setup.c
+++ b/lib/ipc_setup.c
@@ -266,7 +266,7 @@ qb_ipcc_stream_sock_connect(const char *socket_name, int32_t * sock_pt)
 #if defined(QB_LINUX) || defined(QB_CYGWIN)
 	snprintf(address.sun_path + 1, UNIX_PATH_MAX - 1, "%s", socket_name);
 #else
-	snprintf(address.sun_path, UNIX_PATH_MAX, "%s/%s", SOCKETDIR,
+	snprintf(address.sun_path, sizeof(address.sun_path), "%s/%s", SOCKETDIR,
 		 socket_name);
 #endif
 	if (connect(request_fd, (struct sockaddr *)&address,
@@ -385,7 +385,7 @@ qb_ipcs_us_publish(struct qb_ipcs_service * s)
 				    SOCKETDIR);
 			goto error_close;
 		}
-		snprintf(un_addr.sun_path, UNIX_PATH_MAX, "%s/%s", SOCKETDIR,
+		snprintf(un_addr.sun_path, sizeof(un_addr.sun_path), "%s/%s", SOCKETDIR,
 			 s->name);
 		unlink(un_addr.sun_path);
 	}

--- a/lib/ipc_socket.c
+++ b/lib/ipc_socket.c
@@ -53,7 +53,7 @@ set_sock_addr(struct sockaddr_un *address, const char *socket_name)
 #if defined(QB_LINUX) || defined(QB_CYGWIN)
 	snprintf(address->sun_path + 1, UNIX_PATH_MAX - 1, "%s", socket_name);
 #else
-	snprintf(address->sun_path, UNIX_PATH_MAX, "%s/%s", SOCKETDIR,
+	snprintf(address->sun_path, sizeof(address->sun_path), "%s/%s", SOCKETDIR,
 		 socket_name);
 #endif
 }


### PR DESCRIPTION
Use sizeof to get the correct size of the sockaddr_un.sun_path member in a portable way.

This gets Corosync up and limping on Mac OS X (10.9).

The configure process on Darwin ends up undefining UNIX_PATH_MAX, which is then "corrected" to 108 in lib/util_int.h.  In Mac OS X 10.9 this value is actually 104, and the C library aborts based on the incorrect length specification.

UNIX_PATH_MAX is not actually needed, as we can simply use sizeof to get this size portably and correctly at compile time.  If we change this for the Linux case too we can simply remove UNIX_PATH_MAX completely.
