### PR TITLE
Fix: ipc_setup: Destory connection with client, when setup failed

### DIFF
--- a/lib/ipc_setup.c
+++ b/lib/ipc_setup.c
@@ -531,6 +531,7 @@ send_response:
 				       "Error in connection setup (%s)",
 				       c->description);
 		}
+		c->state = QB_IPCS_CONNECTION_ESTABLISHED;
 		qb_ipcs_disconnect(c);
 	}
 	return res;


### PR DESCRIPTION
When setup of the connection from a client (for example, crm_mon) to cib process failed, the cib process is not finished at the time of a service stop.

```
Dec  6 16:59:56 vm1 cib[21947]:     info: crm_client_new: Connecting 0x163a710 for uid=0 gid=0 pid=22075 id=ddb180e6-6cd8-44f1-a5a4-e4106eadf551
Dec  6 16:59:56 vm1 cib[21947]:    error: handle_new_connection: Error in connection setup (21947-22075-13): Broken pipe (32)
--(snip)--
Dec  6 17:01:37 vm1 pacemakerd[21943]:   notice: pcmk_shutdown_worker: Shuting down Pacemaker
--(snip)--
Dec  6 17:02:18 vm1 cib[21947]:     info: crm_signal_dispatch: Invoking handler for signal 15: Terminated
Dec  6 17:02:18 vm1 cib[21947]:    error: disconnect_remote_client: Disconnecting <null>... Not implemented
Dec  6 17:02:18 vm1 cib[21947]:     info: cib_shutdown: Disconnected 2 clients
Dec  6 17:02:18 vm1 cib[21947]:     info: cib_shutdown: Waiting on 1 clients to disconnect (0)
```

```
root     23197 23194  0 17:01 ?        00:00:00 stop pacemaker.combined
root     21934     1  2 16:58 ?        00:00:10 corosync
root     21943     1  0 16:58 ?        00:00:00 pacemakerd
496      21947 21943 23 16:58 ?        00:01:26 /usr/libexec/pacemaker/cib
```

```
--(snip)--
Dec  6 17:05:18 vm1 pacemakerd[21943]:    error: escalate_shutdown: Child cib not terminating in a timely manner, forcing
Dec  6 17:05:18 vm1 pacemakerd[21943]:   notice: stop_child: Stopping cib: Sent -11 to process 21947
Dec  6 17:05:18 vm1 pacemakerd[21943]:    error: child_death_dispatch: Managed process 21947 (cib) dumped core
```

I think that cib_ipc_closed[1] should be called, when setup of ipc failed.

[1] https://github.com/ClusterLabs/pacemaker/blob/93a37bf6ea/cib/callbacks.c#L133
