### PR TITLE
High: ipcs: Prevent ipc server use after free.

### DIFF
--- a/lib/ipc_setup.c
+++ b/lib/ipc_setup.c
@@ -431,6 +431,7 @@ int32_t
 qb_ipcs_us_withdraw(struct qb_ipcs_service * s)
 {
 	qb_util_log(LOG_INFO, "withdrawing server sockets");
+	s->poll_fns.dispatch_del(s->server_sock);
 	shutdown(s->server_sock, SHUT_RDWR);
 	close(s->server_sock);
 	return 0;


### PR DESCRIPTION
The ipc server registers the bind socket to
the poll loop in order to be alerted to new
connection requests. Upon shutdown, the ipc server
does not remove this poll entry. This patch fixes
this use after free.
