### PR TITLE
Low: ipc_setup.c: Add log for EAGAIN

### DIFF
--- a/lib/ipc_setup.c
+++ b/lib/ipc_setup.c
@@ -526,6 +526,9 @@ send_response:
 		if (res == -EACCES) {
 			qb_util_log(LOG_ERR, "Invalid IPC credentials (%s).",
 				    c->description);
+		} else if (res == -EAGAIN) {
+			qb_util_log(LOG_WARNING, "Denied connection, is not ready (%s)",
+				    c->description);
 		} else {
 			errno = -res;
 			qb_util_perror(LOG_ERR,


### PR DESCRIPTION
The following Error log ('Error in connection setup') may be output at the time of start of corosync.

```
Nov 28 14:13:28 vm02 corosync[2381]:  [MAIN  ] Corosync Cluster Engine ('2.3.2'): started and ready to provide service.
Nov 28 14:13:28 vm02 corosync[2381]:  [MAIN  ] Corosync built-in features: watchdog upstart snmp pie relro bindnow
Nov 28 14:13:28 vm02 corosync[2382]:  [TOTEM ] Initializing transport (UDP/IP Multicast).
Nov 28 14:13:28 vm02 corosync[2382]:  [TOTEM ] Initializing transmit/receive security (NSS) crypto: aes256 hash: sha1
Nov 28 14:13:28 vm02 corosync[2382]:  [TOTEM ] Initializing transport (UDP/IP Multicast).
Nov 28 14:13:28 vm02 corosync[2382]:  [TOTEM ] Initializing transmit/receive security (NSS) crypto: aes256 hash: sha1
Nov 28 14:13:28 vm02 corosync[2382]:  [TOTEM ] The network interface [192.168.101.132] is now up.
Nov 28 14:13:28 vm02 corosync[2382]:  [SERV  ] Service engine loaded: corosync configuration map access [0]
Nov 28 14:13:28 vm02 corosync[2382]:  [QB    ] server name: cmap
Nov 28 14:13:28 vm02 corosync[2382]:  [SERV  ] Service engine loaded: corosync configuration service [1]
Nov 28 14:13:28 vm02 corosync[2382]:  [QB    ] server name: cfg
Nov 28 14:13:28 vm02 corosync[2382]:  [SERV  ] Service engine loaded: corosync cluster closed process group service v1.01 [2]
Nov 28 14:13:28 vm02 corosync[2382]:  [QB    ] server name: cpg
Nov 28 14:13:28 vm02 corosync[2382]:  [SERV  ] Service engine loaded: corosync profile loading service [4]
Nov 28 14:13:28 vm02 corosync[2382]:  [WD    ] Watchdog is now been tickled by corosync.
Nov 28 14:13:28 vm02 corosync[2382]:  [WD    ] no resources configured.
Nov 28 14:13:28 vm02 corosync[2382]:  [SERV  ] Service engine loaded: corosync watchdog service [7]
Nov 28 14:13:28 vm02 corosync[2382]:  [QUORUM] Using quorum provider corosync_votequorum
Nov 28 14:13:28 vm02 corosync[2382]:  [SERV  ] Service engine loaded: corosync vote quorum service v1.0 [5]
Nov 28 14:13:28 vm02 corosync[2382]:  [QB    ] server name: votequorum
Nov 28 14:13:28 vm02 corosync[2382]:  [SERV  ] Service engine loaded: corosync cluster quorum service v0.1 [3]
Nov 28 14:13:28 vm02 corosync[2382]:  [QB    ] server name: quorum
Nov 28 14:13:28 vm02 corosync[2382]:  [TOTEM ] The network interface [192.168.102.132] is now up.

Nov 28 14:13:28 vm02 corosync[2382]:  [QB    ] Error in connection setup (2382-2387-25): Resource temporarily unavailable (11)

Nov 28 14:13:28 vm02 corosync[2382]:  [TOTEM ] Incrementing problem counter for seqid 2 iface 192.168.101.132 to [1 of 10]
Nov 28 14:13:28 vm02 corosync[2382]:  [TOTEM ] A new membership (192.168.101.131:26632) was formed. Members joined: -1062705789 -1062705788
Nov 28 14:13:28 vm02 corosync[2382]:  [QUORUM] This node is within the primary component and will provide service.
Nov 28 14:13:28 vm02 corosync[2382]:  [QUORUM] Members[2]: -1062705789 -1062705788
Nov 28 14:13:28 vm02 corosync[2382]:  [MAIN  ] Completed service synchronization, ready to provide service.
```

pid 2387 is corosync-cfgtool command executed by a start script of corosync.
https://github.com/corosync/corosync/blob/fbe8768f1b/init/corosync.conf.in#L28
https://github.com/corosync/corosync/blob/fbe8768f1b/init/corosync.in#L88

Since a user gets confused ("something has to be done about this Error?"),
I think that WARN log is good at the time of EAGAIN.
