### PR TITLE
epoll: don't miss poll events under high load

### DIFF
--- a/lib/loop_poll_epoll.c
+++ b/lib/loop_poll_epoll.c
@@ -178,16 +178,12 @@ retry_poll:
 			 */
 			continue;
 		}
-		if (events[i].events == pe->ufd.revents ||
-		    pe->state == QB_POLL_ENTRY_JOBLIST) {
-			/*
-			 * entry already in the job queue.
-			 */
-			continue;
-		}
-		pe->ufd.revents = _epoll_to_poll_event_(events[i].events);
 
-		new_jobs += pe->add_to_jobs(src->l, pe);
+		pe->ufd.revents |= _epoll_to_poll_event_(events[i].events);
+
+		if (pe->state != QB_POLL_ENTRY_JOBLIST) {
+			new_jobs += pe->add_to_jobs(src->l, pe);
+		}
 	}
 
 	return new_jobs;


### PR DESCRIPTION
If multiple epoll sources generate events simultaneously, it is possible
for more jobs to be added to particular priority level than will be
handled in one go by qb_loop_run_level(). If one of these epoll sources
gains a new event (say, by switching from "readable" to "readable and
writeable"), then this new event would be missed.

To fix this, merge new epoll events into revents regardless of whether
the job is on the joblist. When the job is dispatched, revents will be
cleared, or the epoll source will be deleted entirely.
