### PR TITLE
Fix a couple of bugs in the ringbuffer code

### DIFF
--- a/lib/ringbuffer.c
+++ b/lib/ringbuffer.c
@@ -886,7 +886,11 @@ qb_rb_create_from_file(int32_t fd, uint32_t flags)
 	 * 6. data
 	 */
 	n_required = (word_size * sizeof(uint32_t));
-	rb = qb_rb_open("create_from_file", n_required,
+
+	/*
+	 * qb_rb_open adds QB_RB_CHUNK_MARGIN + 1 to the requested size.
+	 */
+	rb = qb_rb_open("create_from_file", n_required - (QB_RB_CHUNK_MARGIN + 1),
 			QB_RB_FLAG_CREATE | QB_RB_FLAG_NO_SEMAPHORE, 0);
 	if (rb == NULL) {
 		return NULL;


### PR DESCRIPTION
This branch fixes two bugs in the ringbuffer code:
- qb_log_target_formats() does not support formatting size_t values with
  %zd.  Use %ld to format them as long integers instead.
- qb_rb_open() expects the size field to represent the maximum chunk size.
  It adds QB_RB_CHUNK_MARGIN + 1 and rounds up to the page size to
  determine the ringbuffer's total size. When creating a ringbuffer from a
  file we must compensate by subtracting this amount from the file's size.
