### PR TITLE
ipcs: avoid potential hang on new connections

### DIFF
--- a/lib/ipc_shm.c
+++ b/lib/ipc_shm.c
@@ -318,7 +318,7 @@ qb_ipcs_shm_connect(struct qb_ipcs_service *s,
 		goto cleanup_request_response;
 	}
 
-	res = s->poll_fns.dispatch_add(s->poll_priority,
+	res = s->poll_fns.dispatch_mod(s->poll_priority,
 				       c->setup.u.us.sock,
 				       POLLIN | POLLPRI | POLLNVAL,
 				       c, qb_ipcs_dispatch_connection_request);

--- a/lib/ipc_socket.c
+++ b/lib/ipc_socket.c
@@ -592,7 +592,7 @@ _sock_add_to_mainloop(struct qb_ipcs_connection *c)
 		return res;
 	}
 
-	res = c->service->poll_fns.dispatch_add(c->service->poll_priority,
+	res = c->service->poll_fns.dispatch_mod(c->service->poll_priority,
 						c->setup.u.us.sock,
 						POLLIN | POLLPRI | POLLNVAL,
 						c, _sock_connection_liveliness);


### PR DESCRIPTION
If an IPC client connects to the server but does not provide an
AUTHENTICATE message, the IPC server will hang.

To fix this, add the newly accepted connection to the mainloop
immediately. Once the AUTHENTICATE message is received, finish the
connection setup as normal.

Note that this change requires IPC servers to implement dispatch_mod
correctly, which until now had not been necessary. examples/ipcserver.c
implemented dispatch_mod for the QB mainloop only; this commit includes
the changes demonstrating how to support dispatch_mod with the GLib
mainloop.
