### PR TITLE
fix invalid option when run 'ipcclient -h'

### DIFF
--- a/examples/ipcclient.c
+++ b/examples/ipcclient.c
@@ -192,7 +192,7 @@ int
 main(int argc, char *argv[])
 {
 	qb_ipcc_connection_t *conn;
-	const char *options = "eb";
+	const char *options = "ebh";
 	int32_t opt;
 
 	while ((opt = getopt(argc, argv, options)) != -1) {


### PR DESCRIPTION
Hi libqb master,
there is one problem when run 'ipcclient -h', it will print out invalid option. this is because of options missing 'h'.
Please check the patch for this problem. Thanks a lot.
