### PR TITLE
High: ipc_socket: Signalhandler must be resetted to Default, use only cl...

### DIFF
--- a/lib/ipc_socket.c
+++ b/lib/ipc_socket.c
@@ -79,6 +79,9 @@ qb_ipc_dgram_sock_setup(const char *base_name,
 	}
 	snprintf(sock_path, PATH_MAX, "%s-%s", base_name, service_name);
 	set_sock_addr(&local_address, sock_path);
+#if !(defined(QB_LINUX) || defined(QB_CYGWIN))
+	res = unlink(local_address.sun_path);
+#endif
 	res = bind(request_fd, (struct sockaddr *)&local_address,
 		   sizeof(local_address));
 	if (res < 0) {
@@ -338,6 +341,7 @@ qb_ipc_socket_sendv(struct qb_ipc_one_way *one_way, const struct iovec *iov,
 		rc = _finish_connecting(one_way);
 		if (rc < 0) {
 			qb_util_perror(LOG_ERR, "socket connect-on-sendv");
+			qb_sigpipe_ctl(QB_SIGPIPE_DEFAULT);
 			return rc;
 		}
 	}
@@ -387,20 +391,29 @@ retry_peek:
 		      MSG_NOSIGNAL | MSG_PEEK);
 
 	if (result == -1) {
+
 		if (errno != EAGAIN) {
-			return -errno;
+			final_rc = -errno;
+#if !(defined(QB_LINUX) || defined(QB_CYGWIN))
+			if (errno == ECONNRESET || errno == EPIPE) {
+				final_rc = -ENOTCONN;
+			}
+#endif
+			goto cleanup_sigpipe;
 		}
 
 		/* check to see if we have enough time left to try again */
 		if (time_waited < timeout || timeout == -1) {
 			result = qb_ipc_us_ready(one_way, NULL, time_to_wait, POLLIN);
 			if (qb_ipc_us_sock_error_is_disconnected(result)) {
-				return result;
+				final_rc = result;
+				goto cleanup_sigpipe;
 			}
 			time_waited += time_to_wait;
 			goto retry_peek;
 		} else if (time_waited >= timeout) {
-			return -ETIMEDOUT;
+			final_rc = -ETIMEDOUT;
+			goto cleanup_sigpipe;
 		}
 	}
 	if (result >= sizeof(struct qb_ipc_request_header)) {


### PR DESCRIPTION
...eanup_sigpipe to return from qb_ipc_dgram_sock_setup.

Some OS like Solaris/Illumos return with ECONNRESET or EPIPE in the case of a disconnecting peer.
Change the return code to ENOTCONN and continue.
