### PR TITLE
Resolve issue #139

### DIFF
--- a/lib/ipc_setup.c
+++ b/lib/ipc_setup.c
@@ -110,7 +110,7 @@ retry_recv:
 	}
 
 	processed += result;
-	if (processed != len) {
+	if (processed < len) {
 		goto retry_recv;
 	}
 	qb_sigpipe_ctl(QB_SIGPIPE_DEFAULT);

--- a/lib/ipc_setup.c
+++ b/lib/ipc_setup.c
@@ -87,8 +87,11 @@ qb_ipc_us_recv_msghdr(int32_t s, struct msghdr *hdr, char *msg, size_t len)
 {
 	int32_t result;
 	int32_t processed = 0;
+	int32_t oldflags;
 
 	qb_sigpipe_ctl(QB_SIGPIPE_IGNORE);
+
+	oldflags = qb_sys_fd_block_set(s);
 
 retry_recv:
 	hdr->msg_iov->iov_base = &msg[processed];
@@ -100,12 +103,18 @@ retry_recv:
 	}
 	if (result == -1) {
 		qb_sigpipe_ctl(QB_SIGPIPE_DEFAULT);
+		if (oldflags >= 0) {
+			qb_sys_fd_flags_restore(s, oldflags);
+		}
 		return -errno;
 	}
 	if (result == 0) {
 		qb_sigpipe_ctl(QB_SIGPIPE_DEFAULT);
 		qb_util_log(LOG_DEBUG,
 			    "recv(fd %d) got 0 bytes assuming ENOTCONN", s);
+		if (oldflags >= 0) {
+			qb_sys_fd_flags_restore(s, oldflags);
+		}
 		return -ENOTCONN;
 	}
 
@@ -114,6 +123,9 @@ retry_recv:
 		goto retry_recv;
 	}
 	qb_sigpipe_ctl(QB_SIGPIPE_DEFAULT);
+	if (oldflags >= 0) {
+		qb_sys_fd_flags_restore(s, oldflags);
+	}
 	assert(processed == len);
 
 	return processed;

--- a/lib/unix.c
+++ b/lib/unix.c
@@ -241,6 +241,40 @@ qb_sys_fd_nonblock_cloexec_set(int32_t fd)
 	return res;
 }
 
+int32_t
+qb_sys_fd_block_set(int32_t fd)
+{
+	 int32_t res = 0;
+	 int32_t oldflags = fcntl(fd, F_GETFL, 0);
+
+	 if (oldflags < 0) {
+		   oldflags = 0;
+	 }
+
+	 oldflags = oldflags & ~((int32_t) O_NONBLOCK);
+
+	 res = fcntl(fd, F_SETFL, oldflags);
+	 if (res == -1) {
+		  qb_util_log(LOG_ERR, "Could not set blocking on fd:%d", fd);
+		  return -errno;
+	 }
+
+	 return oldflags;
+}
+
+int32_t
+qb_sys_fd_flags_restore(int32_t fd, int32_t flags)
+{
+	 int32_t res = 0;
+	 res = fcntl(fd, F_SETFL, flags);
+	 if (res == -1) {
+		  res = -errno;
+		  qb_util_log(LOG_ERR, "Could not set non-blocking on fd:%d", fd);
+	 }
+
+	 return res;
+}
+
 void
 qb_sigpipe_ctl(enum qb_sigpipe_ctl ctl)
 {

--- a/lib/util_int.h
+++ b/lib/util_int.h
@@ -83,6 +83,20 @@ int32_t qb_sys_circular_mmap(int32_t fd, void **buf, size_t bytes);
  */
 int32_t qb_sys_fd_nonblock_cloexec_set(int32_t fd);
 
+/**
+ * Remove O_NONBLOCK on a file descriptor.
+ * @param fd the file descriptor.
+ * @return old flags (>0) (success) or -errno
+ */
+int32_t qb_sys_fd_block_set(int32_t fd);
+
+/**
+ * Set flags on a file descriptor.
+ * @param fd the file descriptor.
+ * @return 0 (success) or -errno
+ */
+int32_t qb_sys_fd_flags_restore(int32_t fd, int32_t flags);
+
 enum qb_sigpipe_ctl {
        QB_SIGPIPE_IGNORE,
        QB_SIGPIPE_DEFAULT,


### PR DESCRIPTION
qb_ipc_us_recv_msghdr loops on EAGAIN until data is ready. By making the socket blocking again, this makes recvmsg wait until data is ready. The socket options are restored afterwards.

Additionally, this breaks looping on processed > len, as this will not work otherwise anyway.