### PR TITLE
Fix alignment issues on hppa

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -253,9 +253,13 @@ case $host_cpu in
 		nongcc_memory_barrier_needed=yes
 		;;
 	arm*)
-		AC_MSG_RESULT([ia64])
+		AC_MSG_RESULT([arm])
 		AC_DEFINE_UNQUOTED([QB_ARCH_ARM], [1], [arm])
 		arch_force_shmlba=yes
+		;;
+	hppa*)
+		AC_MSG_RESULT([hppa])
+		AC_DEFINE_UNQUOTED([QB_ARCH_HPPA], [1], [hppa])
 		;;
 	mips*)
 		AC_MSG_RESULT([ia64])

--- a/lib/ringbuffer.c
+++ b/lib/ringbuffer.c
@@ -138,7 +138,9 @@ qb_rb_open_2(const char *name, size_t size, uint32_t flags,
 	void *shm_addr;
 	long page_size = sysconf(_SC_PAGESIZE);
 
-#ifdef QB_FORCE_SHM_ALIGN
+#ifdef QB_ARCH_HPPA
+	page_size = QB_MAX(page_size, 0x00400000); /* align to page colour */
+#elif defined(QB_FORCE_SHM_ALIGN)
 	page_size = QB_MAX(page_size, 16 * 1024);
 #endif /* QB_FORCE_SHM_ALIGN */
 	/* The user of this api expects the 'size' parameter passed into this function


### PR DESCRIPTION
libqb fails to build on the hppa architecture, because the built-in
testcases fail as can be seen here:
http://buildd.debian-ports.org/status/fetch.php?pkg=libqb&arch=hppa&ver=0.17.0-2&stamp=1409458262

I did analyzed why they fail, and the reason is that on hppa we have
somewhat more complicated requirements (e.g. alignments) which needs to
be followed in order to mmap shared pages between processes. It's
different than what can be done compared to ia64 and sparc.
The attached patch fixes libqb on the hppa architecture and with it all
testcases finish successful.

By the way, I fixed a small typo in configure.ac too where arm platforms
prints "ia64"...

Forwarded-From: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=760199
Signed-off-by: Christoph Berg <myon@debian.org>