### PR TITLE
Implement extended information logging (aka split logging)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.so.*
 *.3
 *.rpm
+*.swp
 *.pc
 *.log
 Makefile
@@ -27,3 +28,4 @@ abi_dumps
 TAGS
 *~
 test-driver
+tests/*.trs

--- a/include/qb/qblog.h
+++ b/include/qb/qblog.h
@@ -363,18 +363,30 @@ void qb_log_from_external_source_va(const char *function,
  */
 #define qb_log(priority, fmt, args...) qb_logt(priority, 0, fmt, ##args)
 
+/* Define the character used to mark the beginning of "extended" information;
+ * a string equivalent is also defined so clients can use it like:
+ *    qb_log(level, "blah blah "QB_XS" yada yada", __func__);
+ */
+#define QB_XC '\a'
+#define QB_XS "\a"
+
 /**
  * This is similar to perror except it goes into the logging system.
  *
  * @param priority this takes syslog priorities.
  * @param fmt usual printf style format specifiers
  * @param args usual printf style args
+ *
+ * @note Because qb_perror() adds the system error message and error number onto
+ *       the end of the given fmt, that information will become extended
+ *       information if QB_XS is used inside fmt and will not show up in any
+ *       logs that strip extended information.
  */
 #ifndef S_SPLINT_S
 #define qb_perror(priority, fmt, args...) do {				\
 	char _perr_buf_[QB_LOG_STRERROR_MAX_LEN];			\
 	const char *_perr_str_ = qb_strerror_r(errno, _perr_buf_, sizeof(_perr_buf_));	\
-	qb_logt(priority, 0, fmt ": %s (%d)", ##args, _perr_str_, errno);		\
+	qb_logt(priority, 0, fmt ": %s (%d)", ##args, _perr_str_, errno); \
     } while(0)
 #else
 #define qb_perror
@@ -405,6 +417,7 @@ enum qb_log_conf {
 	QB_LOG_CONF_PRIORITY_BUMP,
 	QB_LOG_CONF_STATE_GET,
 	QB_LOG_CONF_FILE_SYNC,
+	QB_LOG_CONF_EXTENDED,
 };
 
 enum qb_log_filter_type {

--- a/lib/log_format.c
+++ b/lib/log_format.c
@@ -460,11 +460,21 @@ qb_vsnprintf_serialize(char *serialize, size_t max_len,
 {
 	char *format;
 	char *p;
+	char *qb_xc;
 	int type_long = QB_FALSE;
 	int type_longlong = QB_FALSE;
         int sformat_length = 0;
         int sformat_precision = QB_FALSE;
 	uint32_t location = my_strlcpy(serialize, fmt, max_len) + 1;
+
+	/* Assume serialized output always wants extended information
+	 * (@todo: add variant of this function that takes argument for whether
+	 * to print extended information, and make this a macro with that
+	 * argument set to QB_TRUE, so callers can honor extended setting)
+	 */
+	if ((qb_xc = strchr(serialize, QB_XC)) != NULL) {
+		*qb_xc = *(qb_xc + 1)? '|' : '\0';
+	}
 
 	format = (char *)fmt;
 	for (;;) {


### PR DESCRIPTION
Amended commits to address issues from review:
* Got rid of unused argument in unit test.
* Replaced exquisite one-liner taking advantage of C short-circuiting with four-line if block ;-)
* Reverted qb_perror() to original implementation and added documentation note about effect of extended information marker on it