### PR TITLE
Fix: valgrind "invalid file descriptor" warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 language: c
 compiler:
   - gcc
-before_install: sudo apt-get install check splint
-install:
- # Deal with issue on Travis builders
- # https://github.com/travis-ci/travis-cookbooks/issues/155
- - "sudo rm -rf /dev/shm && sudo ln -s /run/shm /dev/shm"
+addons:
+        apt:
+                packages:
+                  - check
+                  - splint
 script: ./autogen.sh && ./configure && make check && make distcheck
-notifications:
-  email:
-    recipients:
-      - quarterback-devel@lists.fedorahosted.org
+sudo: false

--- a/README.markdown
+++ b/README.markdown
@@ -1,17 +1,18 @@
 # libqb
 
 ## What is libqb?
-libqb is a library with the primary purpose of providing high performance
-client server reusable features. It provides high performance logging,
-tracing, ipc, and poll.
+libqb is a library with the primary purpose of providing high-performance,
+reusable features for client-server architecture, such as logging,
+tracing, inter-process communication (IPC), and polling.
 
-We don't intend be an all encompassing library, but instead provide very
-specially focused APIs that are highly tuned for maximum performance for client/server applications.
+libqb is not intended to be an all-encompassing library, but instead provide
+focused APIs that are highly tuned for maximum performance for client-server
+applications.
 
 [![Build Status](https://travis-ci.org/ClusterLabs/libqb.png)](https://travis-ci.org/ClusterLabs/libqb)
 
-## For more information look at:
-* [Our wiki](https://github.com/clusterlabs/libqb/wiki)
+## For more information, see:
+* [libqb wiki](https://github.com/clusterlabs/libqb/wiki)
 * [Issues/Bugs](https://github.com/clusterlabs/libqb/issues)
 * [The doxygen generated manual](http://clusterlabs.github.io/libqb/0.16.0/doxygen/)
 * You can build it yourself with the following commands:
@@ -42,8 +43,7 @@ If you find this project useful, you may want to consider supporting its future 
 There are a number of ways to support the project.
 
 * Test and report issues.
-* Help others on the [mailing list](https://fedorahosted.org/mailman/listinfo/quarterback-devel).
+* Help others on the [developers@clusterlabs.org mailing list](http://clusterlabs.org/mailman/listinfo/developers).
 * Contribute documentation, examples and test cases.
 * Contribute patches.
 * Spread the word.
-

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -29,7 +29,7 @@ AM_CPPFLAGS             = -I$(top_builddir)/include -I$(top_srcdir)/include
 
 lib_LTLIBRARIES		= libqb.la
 
-libqb_la_LDFLAGS	= -version-number 0:17:1
+libqb_la_LDFLAGS	= -version-info 17:2:17
 
 source_to_lint		= util.c hdb.c ringbuffer.c ringbuffer_helper.c \
 			  array.c loop.c loop_poll.c loop_job.c \

--- a/lib/ipcc.c
+++ b/lib/ipcc.c
@@ -81,7 +81,9 @@ qb_ipcc_connect(const char *name, size_t max_msg_size)
 	return c;
 
 disconnect_and_cleanup:
-	qb_ipcc_us_sock_close(c->setup.u.us.sock);
+	if (c->setup.u.us.sock >= 0) {
+		qb_ipcc_us_sock_close(c->setup.u.us.sock);
+	}
 	free(c->receive_buf);
 	free(c);
 	errno = -res;

--- a/libqb.spec.in
+++ b/libqb.spec.in
@@ -16,8 +16,9 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildRequires:  autoconf automake libtool doxygen procps check-devel
 
 %description
-libqb provides high performance client server reusable features.
-Initially these are IPC and poll.
+libqb provides high-performance, reusable features for client-server
+architecture, such as logging, tracing, inter-process communication (IPC),
+and polling.
 
 %prep
 %setup -q -n %{name}-%{version}%{?numcomm:.%{numcomm}}%{?alphatag:-%{alphatag}}%{?dirty:-%{dirty}}


### PR DESCRIPTION
This migrates the libtool soname versioning to use -version-info and throws in some minor other tweaks.