### PR TITLE
Increase the length of description field.

### DIFF
--- a/lib/ipc_int.h
+++ b/lib/ipc_int.h
@@ -159,7 +159,7 @@ enum qb_ipcs_connection_state {
 	QB_IPCS_CONNECTION_SHUTTING_DOWN,
 };
 
-#define CONNECTION_DESCRIPTION (16)
+#define CONNECTION_DESCRIPTION (18)
 
 struct qb_ipcs_connection_auth {
 	uid_t uid;

--- a/lib/ipc_int.h
+++ b/lib/ipc_int.h
@@ -159,7 +159,7 @@ enum qb_ipcs_connection_state {
 	QB_IPCS_CONNECTION_SHUTTING_DOWN,
 };
 
-#define CONNECTION_DESCRIPTION (18)
+#define CONNECTION_DESCRIPTION (34) /* INT_MAX length + 3 */
 
 struct qb_ipcs_connection_auth {
 	uid_t uid;


### PR DESCRIPTION
When both the corosync and pacemaker has PID larger or equal 10000
and when the file descriptor is larger or equal 10 the desciption
will have at least 17 characters.

This fixes the issue reported here:
https://bugzilla.redhat.com/show_bug.cgi?id=1114852