### PR TITLE
Fix: ipc: Prevent fd and memory leaks in handle_new_connection()

### DIFF
--- a/lib/ipc_setup.c
+++ b/lib/ipc_setup.c
@@ -556,7 +556,14 @@ send_response:
 				       "Error in connection setup (%s)",
 				       c->description);
 		}
-		qb_ipcs_disconnect(c);
+
+		if (c->state == QB_IPCS_CONNECTION_INACTIVE) {
+			/* This removes the initial alloc ref */
+			qb_ipcs_connection_unref(c);
+		        qb_ipcc_us_sock_close(sock);
+		} else {
+			qb_ipcs_disconnect(c);
+		}
 	}
 	return res;
 }


### PR DESCRIPTION
In handle_new_connection(), connection_accept() could fail, which would
leave the state of the connection inactive. Previously, in this case,
the socket and the allocated qb_ipcs_connection would be leaked.

It can be produced with the following steps:
1) Run pacemaker_remoted without being connected by corosync nodes.
2) Run crm_mon on the same node.
3) The pacemaker_remoted ends up hitting the per-process fd limit.