### PR TITLE
Add missing Makefile rule for generating the auto_check_header_qbconf…

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -56,6 +56,20 @@ auto_c_files = $(patsubst %.h,auto_check_header_%.c,$(public_headers))
 CLEANFILES += $(auto_c_files)
 MAINTAINERCLEANFILES += $(auto_c_files)
 
+#
+# The qbconfig.h file is generated from qbconfig.h.in into the build directory tree.
+# We have to have a separate rule for generating the auto_check_header_ source here.
+#
+$(builddir)/auto_check_header_qbconfig.c: $(top_builddir)/include/qb/qbconfig.h
+	@name=$$(echo "$<" | sed  "s|.*qb/qb||" | sed "s|\.h||") ;\
+	NAME=$$(echo $$name | tr [:lower:] [:upper:]) ;\
+	echo "#include <qb/qb$$name.h>" > $@_ ;\
+	echo "#ifndef QB_$${NAME}_H_DEFINED" >> $@_ ;\
+	echo "#error no header protector in file qb$$name.h" >> $@_ ;\
+	echo "#endif" >> $@_ ;\
+	echo "int main(void) {return 0;}" >> $@_
+	$(AM_V_GEN)mv $@_ $@
+
 $(builddir)/auto_check_header_%.c: $(top_srcdir)/include/qb/%.h
 	@name=$$(echo "$<" | sed  "s|.*qb/qb||" | sed "s|\.h||") ;\
 	NAME=$$(echo $$name | tr [:lower:] [:upper:]) ;\


### PR DESCRIPTION
…ig.c file

Resolves issue #158

Addressing:
```
make[2]: Entering directory `/home/dkopecek/Projects/github/usbguard/src/ThirdParty/libqb/_build/tests'
...
  GEN      auto_check_header_qbarray.c
  CC       auto_check_header_qbarray.o
  CCLD     auto_check_header_qbarray
make[2]: *** No rule to make target `auto_check_header_qbconfig.c', needed by `auto_check_header_qbconfig.o'.  Stop.
make[2]: Leaving directory `/home/dkopecek/Projects/github/usbguard/src/ThirdParty/libqb/_build/tests'
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory `/home/dkopecek/Projects/github/usbguard/src/ThirdParty/libqb/_build'
make: *** [all] Error 2
```