### PR TITLE
ipc: update file permissions on created sockets

### DIFF
--- a/lib/ipc_socket.c
+++ b/lib/ipc_socket.c
@@ -85,7 +85,7 @@ qb_ipc_dgram_sock_setup(const char *base_name,
 	res = bind(request_fd, (struct sockaddr *)&local_address,
 		   sizeof(local_address));
 #if !(defined(QB_LINUX) || defined(QB_CYGWIN))
-	chmod(local_address.sun_path, 0660);
+	chmod(local_address.sun_path, 0666);
 #endif
 	if (res < 0) {
 		goto error_connect;


### PR DESCRIPTION
Follow-up to my last pull request, the mode should have been 666 instead of 660.