### PR TITLE
build: avoid too keen -Wmissing-format-attribute warning

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -489,9 +489,20 @@ for j in $WARNLIST; do
 done
 
 # warnings suppression
+gcc_format_complaints=no
+if test x"$GCC" = xyes && cc_supports_flag -Wmissing-format-attribute; then
+	gcc_format_complaints=yes
+	AC_DEFINE([HAVE_GCC_MISSING_FORMAT_ATTRIBUTE], [],
+		  [gcc supports -Wmissing-format-attribute])
+fi
 if test x"$GCC" = xyes && cc_supports_flag -Wsuggest-attribute=format; then
+	gcc_format_complaints=yes
 	AC_DEFINE([HAVE_GCC_SUGGEST_ATTRIBUTE_FORMAT], [],
 		  [gcc supports -Wsuggest-attribute=format])
+fi
+if test x"$gcc_format_complaints" = xyes; then
+	AC_DEFINE([HAVE_GCC_FORMAT_COMPLAINTS], [],
+		  [gcc can complain about missing format attribute])
 fi
 
 # --- coverage ---

--- a/lib/log.c
+++ b/lib/log.c
@@ -172,11 +172,16 @@ _cs_matches_filter_(struct qb_log_callsite *cs,
  * @param[in]  cs   Callsite containing format to use
  * @param[in]  ap   Variable arguments for format
  */
-#ifdef HAVE_GCC_SUGGEST_ATTRIBUTE_FORMAT
 /* suppress suggestion that we currently can do nothing better about
    as the format specification is hidden in cs argument */
+#ifdef HAVE_GCC_FORMAT_COMPLAINTS
 #pragma GCC diagnostic push
+#ifdef HAVE_GCC_MISSING_FORMAT_ATTRIBUTE
+#pragma GCC diagnostic ignored "-Wmissing-format-attribute"
+#endif
+#ifdef HAVE_GCC_SUGGEST_ATTRIBUTE_FORMAT
 #pragma GCC diagnostic ignored "-Wsuggest-attribute=format"
+#endif
 #endif
 static inline void
 cs_format(char *str, struct qb_log_callsite *cs, va_list ap)
@@ -194,7 +199,7 @@ cs_format(char *str, struct qb_log_callsite *cs, va_list ap)
 		str[len - 1] = '\0';
 	}
 }
-#ifdef HAVE_GCC_SUGGEST_ATTRIBUTE_FORMAT
+#ifdef HAVE_GCC_FORMAT_COMPLAINTS
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
Grouped with pre-existing -Wsuggest-attribute=format treatment.