### PR TITLE
tests: refactor test case defs using versatile add_tcase macro

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -29,6 +29,8 @@ noinst_PROGRAMS = bmc bmcpt bms rbwriter rbreader loop bench-log \
 	auto_check_header_qbipcc auto_check_header_qbipcs auto_check_header_qblog \
 	auto_check_header_qbmap auto_check_header_qbutil format_compare_speed
 
+noinst_HEADERS = check_common.h
+
 format_compare_speed_SOURCES = format_compare_speed.c $(top_builddir)/include/qb/qbutil.h
 format_compare_speed_LDADD = $(top_builddir)/lib/libqb.la
 

--- a/tests/check_array.c
+++ b/tests/check_array.c
@@ -22,7 +22,8 @@
  */
 
 #include "os_base.h"
-#include <check.h>
+
+#include "check_common.h"
 
 #include <qb/qbdefs.h>
 #include <qb/qblog.h>
@@ -139,21 +140,10 @@ static Suite *array_suite(void)
 	TCase *tc;
 	Suite *s = suite_create("qb_array");
 
-	tc = tcase_create("limits");
-	tcase_add_test(tc, test_array_limits);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("alloc_free");
-	tcase_add_test(tc, test_array_alloc_free);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("correct_retrieval");
-	tcase_add_test(tc, test_array_correct_retrieval);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("static_memory");
-	tcase_add_test(tc, test_array_static_memory);
-	suite_add_tcase(s, tc);
+	add_tcase(s, tc, test_array_limits);
+	add_tcase(s, tc, test_array_alloc_free);
+	add_tcase(s, tc, test_array_correct_retrieval);
+	add_tcase(s, tc, test_array_static_memory);
 
 	return s;
 }

--- a/tests/check_common.h
+++ b/tests/check_common.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2016 Red Hat, Inc.
+ *
+ * All rights reserved.
+ *
+ * Author: Jan Pokorny <jpokorny@redhat.com>
+ *
+ * This file is part of libqb.
+ *
+ * libqb is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * libqb is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with libqb.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef QB_CHECK_COMMON_H_DEFINED
+#define QB_CHECK_COMMON_H_DEFINED
+
+#include <check.h>
+
+/*
+    Auxiliary macros
+ */
+
+#define JOIN(a, b)		a##b
+#define _STRINGIFY(arg)		#arg
+#define STRINGIFY(arg)		_STRINGIFY(arg)
+
+/* wide-spread technique, see, e.g.,
+   http://cplusplus.co.il/2010/07/17/variadic-macro-to-count-number-of-arguments
+ */
+#define VA_ARGS_CNT(...)	VA_ARGS_CNT_IMPL(__VA_ARGS__,8,7,6,5,4,3,2,1,_)
+#define VA_ARGS_CNT_IMPL(_1,_2,_3,_4,_5,_6,_7,_8,N,...)		N
+
+/* add_tcase "overloading" per argument count;
+   "func" argument is assumed to always starts with "test_", which is skipped
+   for the purpose of naming the respective test case that's being created */
+
+#define add_tcase_select(cnt)	JOIN(add_tcase_, cnt)
+#define add_tcase_3(suite, tcase, func) \
+	do { \
+		(tcase) = tcase_create(STRINGIFY(func) + sizeof("test")); \
+		tcase_add_test((tcase), func); \
+		suite_add_tcase((suite), (tcase)); \
+	} while (0)
+#define add_tcase_4(suite, tcase, func, timeout) \
+	do { \
+		(tcase) = tcase_create(STRINGIFY(func) + sizeof("test")); \
+		tcase_add_test((tcase), func); \
+		tcase_set_timeout((tcase), (timeout)); \
+		suite_add_tcase((suite), (tcase)); \
+	} while (0)
+
+/*
+    Use-me macros
+ */
+
+/* add_tcase(<dest-suite>, <testcase-tmp-storage>, <function>[, <timeout>]) */
+#define add_tcase(...)	add_tcase_select(VA_ARGS_CNT(__VA_ARGS__))(__VA_ARGS__)
+
+#endif

--- a/tests/check_ipc.c
+++ b/tests/check_ipc.c
@@ -24,7 +24,8 @@
 #include "os_base.h"
 #include <sys/wait.h>
 #include <signal.h>
-#include <check.h>
+
+#include "check_common.h"
 
 #include <qb/qbdefs.h>
 #include <qb/qblog.h>
@@ -877,7 +878,7 @@ test_ipc_dispatch(void)
 	verify_graceful_stop(pid);
 }
 
-START_TEST(test_ipc_disp_us)
+START_TEST(test_ipc_dispatch_us)
 {
 	qb_enter();
 	ipc_type = QB_IPC_SOCKET;
@@ -1332,7 +1333,7 @@ START_TEST(test_ipc_server_fail_soc)
 }
 END_TEST
 
-START_TEST(test_ipc_disp_shm)
+START_TEST(test_ipc_dispatch_shm)
 {
 	qb_enter();
 	ipc_type = QB_IPC_SHM;
@@ -1482,65 +1483,18 @@ make_shm_suite(void)
 	TCase *tc;
 	Suite *s = suite_create("shm");
 
-	tc = tcase_create("ipc_txrx_shm_timeout");
-	tcase_add_test(tc, test_ipc_txrx_shm_timeout);
-	tcase_set_timeout(tc, 30);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("ipc_server_fail_shm");
-	tcase_add_test(tc, test_ipc_server_fail_shm);
-	tcase_set_timeout(tc, 8);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("ipc_txrx_shm_block");
-	tcase_add_test(tc, test_ipc_txrx_shm_block);
-	tcase_set_timeout(tc, 8);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("ipc_txrx_shm_tmo");
-	tcase_add_test(tc, test_ipc_txrx_shm_tmo);
-	tcase_set_timeout(tc, 8);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("ipc_fc_shm");
-	tcase_add_test(tc, test_ipc_fc_shm);
-	tcase_set_timeout(tc, 8);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("ipc_dispatch_shm");
-	tcase_add_test(tc, test_ipc_disp_shm);
-	tcase_set_timeout(tc, 16);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("ipc_stress_test_shm");
-	tcase_add_test(tc, test_ipc_stress_test_shm);
-	tcase_set_timeout(tc, 16);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("ipc_bulk_events_shm");
-	tcase_add_test(tc, test_ipc_bulk_events_shm);
-	tcase_set_timeout(tc, 16);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("ipc_exit_shm");
-	tcase_add_test(tc, test_ipc_exit_shm);
-	tcase_set_timeout(tc, 8);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("ipc_event_on_created_shm");
-	tcase_add_test(tc, test_ipc_event_on_created_shm);
-	tcase_set_timeout(tc, 10);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("ipc_service_ref_count_shm");
-	tcase_add_test(tc, test_ipc_service_ref_count_shm);
-	tcase_set_timeout(tc, 10);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("ipc_stress_connections_shm");
-	tcase_add_test(tc, test_ipc_stress_connections_shm);
-	tcase_set_timeout(tc, 3600);
-	suite_add_tcase(s, tc);
+	add_tcase(s, tc, test_ipc_txrx_shm_timeout, 30);
+	add_tcase(s, tc, test_ipc_server_fail_shm, 8);
+	add_tcase(s, tc, test_ipc_txrx_shm_block, 8);
+	add_tcase(s, tc, test_ipc_txrx_shm_tmo, 8);
+	add_tcase(s, tc, test_ipc_fc_shm, 8);
+	add_tcase(s, tc, test_ipc_dispatch_shm, 16);
+	add_tcase(s, tc, test_ipc_stress_test_shm, 16);
+	add_tcase(s, tc, test_ipc_bulk_events_shm, 16);
+	add_tcase(s, tc, test_ipc_exit_shm, 8);
+	add_tcase(s, tc, test_ipc_event_on_created_shm, 10);
+	add_tcase(s, tc, test_ipc_service_ref_count_shm, 10);
+	add_tcase(s, tc, test_ipc_stress_connections_shm, 3600);
 
 	return s;
 }
@@ -1551,75 +1505,20 @@ make_soc_suite(void)
 	Suite *s = suite_create("socket");
 	TCase *tc;
 
-	tc = tcase_create("ipc_txrx_us_timeout");
-	tcase_add_test(tc, test_ipc_txrx_us_timeout);
-	tcase_set_timeout(tc, 30);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("ipc_max_dgram_size");
-	tcase_add_test(tc, test_ipc_max_dgram_size);
-	tcase_set_timeout(tc, 30);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("ipc_server_fail_soc");
-	tcase_add_test(tc, test_ipc_server_fail_soc);
-	tcase_set_timeout(tc, 8);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("ipc_txrx_us_block");
-	tcase_add_test(tc, test_ipc_txrx_us_block);
-	tcase_set_timeout(tc, 8);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("ipc_txrx_us_tmo");
-	tcase_add_test(tc, test_ipc_txrx_us_tmo);
-	tcase_set_timeout(tc, 8);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("ipc_fc_us");
-	tcase_add_test(tc, test_ipc_fc_us);
-	tcase_set_timeout(tc, 8);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("ipc_exit_us");
-	tcase_add_test(tc, test_ipc_exit_us);
-	tcase_set_timeout(tc, 8);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("ipc_dispatch_us");
-	tcase_add_test(tc, test_ipc_disp_us);
-	tcase_set_timeout(tc, 16);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("ipc_stress_test_us");
-	tcase_add_test(tc, test_ipc_stress_test_us);
-	tcase_set_timeout(tc, 60);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("ipc_bulk_events_us");
-	tcase_add_test(tc, test_ipc_bulk_events_us);
-	tcase_set_timeout(tc, 16);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("ipc_event_on_created_us");
-	tcase_add_test(tc, test_ipc_event_on_created_us);
-	tcase_set_timeout(tc, 10);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("ipc_disconnect_after_created_us");
-	tcase_add_test(tc, test_ipc_disconnect_after_created_us);
-	tcase_set_timeout(tc, 10);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("ipc_service_ref_count_us");
-	tcase_add_test(tc, test_ipc_service_ref_count_us);
-	tcase_set_timeout(tc, 10);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("ipc_stress_connections_us");
-	tcase_add_test(tc, test_ipc_stress_connections_us);
-	tcase_set_timeout(tc, 3600);
-	suite_add_tcase(s, tc);
+	add_tcase(s, tc, test_ipc_txrx_us_timeout, 30);
+	add_tcase(s, tc, test_ipc_max_dgram_size, 30);
+	add_tcase(s, tc, test_ipc_server_fail_soc, 8);
+	add_tcase(s, tc, test_ipc_txrx_us_block, 8);
+	add_tcase(s, tc, test_ipc_txrx_us_tmo, 8);
+	add_tcase(s, tc, test_ipc_fc_us, 8);
+	add_tcase(s, tc, test_ipc_exit_us, 8);
+	add_tcase(s, tc, test_ipc_dispatch_us, 16);
+	add_tcase(s, tc, test_ipc_stress_test_us, 60);
+	add_tcase(s, tc, test_ipc_bulk_events_us, 16);
+	add_tcase(s, tc, test_ipc_event_on_created_us, 10);
+	add_tcase(s, tc, test_ipc_disconnect_after_created_us, 10);
+	add_tcase(s, tc, test_ipc_service_ref_count_us, 10);
+	add_tcase(s, tc, test_ipc_stress_connections_us, 3600);
 
 	return s;
 }

--- a/tests/check_log.c
+++ b/tests/check_log.c
@@ -23,7 +23,8 @@
 
 #include "os_base.h"
 #include <pthread.h>
-#include <check.h>
+
+#include "check_common.h"
 
 #include <qb/qbdefs.h>
 #include <qb/qbutil.h>
@@ -799,51 +800,19 @@ log_suite(void)
 	TCase *tc;
 	Suite *s = suite_create("logging");
 
-	tc = tcase_create("va_serialize");
-	tcase_add_test(tc, test_va_serialize);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("limits");
-	tcase_add_test(tc, test_log_stupid_inputs);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("basic");
-	tcase_add_test(tc, test_log_basic);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("format");
-	tcase_add_test(tc, test_log_format);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("enable");
-	tcase_add_test(tc, test_log_enable);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("threads");
-	tcase_add_test(tc, test_log_threads);
-	tcase_set_timeout(tc, 360);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("long_msg");
-	tcase_add_test(tc, test_log_long_msg);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("filter_ft");
-	tcase_add_test(tc, test_log_filter_fn);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("threaded_logging");
-	tcase_add_test(tc, test_threaded_logging);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("extended_information");
-	tcase_add_test(tc, test_extended_information);
-	suite_add_tcase(s, tc);
+	add_tcase(s, tc, test_va_serialize);
+	add_tcase(s, tc, test_log_stupid_inputs);
+	add_tcase(s, tc, test_log_basic);
+	add_tcase(s, tc, test_log_format);
+	add_tcase(s, tc, test_log_enable);
+	add_tcase(s, tc, test_log_threads, 360);
+	add_tcase(s, tc, test_log_long_msg);
+	add_tcase(s, tc, test_log_filter_fn);
+	add_tcase(s, tc, test_threaded_logging);
+	add_tcase(s, tc, test_extended_information);
 
 #ifdef HAVE_SYSLOG_TESTS
-	tc = tcase_create("syslog");
-	tcase_add_test(tc, test_syslog);
-	suite_add_tcase(s, tc);
+	add_tcase(s, tc, test_syslog);
 #endif
 
 	return s;

--- a/tests/check_loop.c
+++ b/tests/check_loop.c
@@ -22,7 +22,8 @@
  */
 
 #include "os_base.h"
-#include <check.h>
+
+#include "check_common.h"
 
 #include <qb/qbdefs.h>
 #include <qb/qbutil.h>
@@ -331,35 +332,13 @@ static Suite *loop_job_suite(void)
 	TCase *tc;
 	Suite *s = suite_create("loop_job");
 
-	tc = tcase_create("limits");
-	tcase_add_test(tc, test_loop_job_input);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("run_one");
-	tcase_add_test(tc, test_loop_job_1);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("run_recursive");
-	tcase_add_test(tc, test_loop_job_4);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("run_500");
-	tcase_add_test(tc, test_loop_job_nuts);
-	tcase_set_timeout(tc, 5);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("rate_limit");
-	tcase_add_test(tc, test_job_rate_limit);
-	tcase_set_timeout(tc, 5);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("add_del");
-	tcase_add_test(tc, test_job_add_del);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("order");
-	tcase_add_test(tc, test_loop_job_order);
-	suite_add_tcase(s, tc);
+	add_tcase(s, tc, test_loop_job_input);
+	add_tcase(s, tc, test_loop_job_1);
+	add_tcase(s, tc, test_loop_job_4);
+	add_tcase(s, tc, test_loop_job_nuts, 5);
+	add_tcase(s, tc, test_job_rate_limit, 5);
+	add_tcase(s, tc, test_job_add_del);
+	add_tcase(s, tc, test_loop_job_order);
 
 	return s;
 }
@@ -710,24 +689,11 @@ loop_timer_suite(void)
 	TCase *tc;
 	Suite *s = suite_create("loop_timers");
 
-	tc = tcase_create("limits");
-	tcase_add_test(tc, test_loop_timer_input);
-	suite_add_tcase(s, tc);
+	add_tcase(s, tc, test_loop_timer_input);
+	add_tcase(s, tc, test_loop_timer_basic, 30);
+	add_tcase(s, tc, test_loop_timer_precision, 30);
+	add_tcase(s, tc, test_loop_timer_expire_leak, 30);
 
-	tc = tcase_create("basic");
-	tcase_add_test(tc, test_loop_timer_basic);
-	tcase_set_timeout(tc, 30);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("precision");
-	tcase_add_test(tc, test_loop_timer_precision);
-	tcase_set_timeout(tc, 30);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("expire_leak");
-	tcase_add_test(tc, test_loop_timer_expire_leak);
-	tcase_set_timeout(tc, 30);
-	suite_add_tcase(s, tc);
 	return s;
 }
 
@@ -737,18 +703,9 @@ loop_signal_suite(void)
 	TCase *tc;
 	Suite *s = suite_create("loop_signal_suite");
 
-	tc = tcase_create("signals");
-	tcase_add_test(tc, test_loop_sig_handling);
-	tcase_set_timeout(tc, 10);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("sig_only_one");
-	tcase_add_test(tc, test_loop_sig_only_get_one);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("sig_delete");
-	tcase_add_test(tc, test_loop_sig_delete);
-	suite_add_tcase(s, tc);
+	add_tcase(s, tc, test_loop_sig_handling, 10);
+	add_tcase(s, tc, test_loop_sig_only_get_one);
+	add_tcase(s, tc, test_loop_sig_delete);
 
 	return s;
 }

--- a/tests/check_map.c
+++ b/tests/check_map.c
@@ -21,7 +21,9 @@
  * along with libqb.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "os_base.h"
-#include <check.h>
+
+#include "check_common.h"
+
 #include <qb/qbdefs.h>
 #include <qb/qblog.h>
 #include <qb/qbmap.h>
@@ -910,80 +912,28 @@ map_suite(void)
 	TCase *tc;
 	Suite *s = suite_create("qb_map");
 
-	tc = tcase_create("skiplist_simple");
-	tcase_add_test(tc, test_skiplist_simple);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("hashtable_simple");
-	tcase_add_test(tc, test_hashtable_simple);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("trie_simple");
-	tcase_add_test(tc, test_trie_simple);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("trie_partial_iterate");
-	tcase_add_test(tc, test_trie_partial_iterate);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("skiplist_remove");
-	tcase_add_test(tc, test_skiplist_remove);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("hashtable_remove");
-	tcase_add_test(tc, test_hashtable_remove);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("trie_notifications");
-	tcase_add_test(tc, test_trie_notifications);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("hash_notifications");
-	tcase_add_test(tc, test_hash_notifications);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("skiplist_notifications");
-	tcase_add_test(tc, test_skiplist_notifications);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("skiplist_search");
-	tcase_add_test(tc, test_skiplist_search);
-	suite_add_tcase(s, tc);
+	add_tcase(s, tc, test_skiplist_simple);
+	add_tcase(s, tc, test_hashtable_simple);
+	add_tcase(s, tc, test_trie_simple);
+	add_tcase(s, tc, test_trie_partial_iterate);
+	add_tcase(s, tc, test_skiplist_remove);
+	add_tcase(s, tc, test_hashtable_remove);
+	add_tcase(s, tc, test_trie_notifications);
+	add_tcase(s, tc, test_hash_notifications);
+	add_tcase(s, tc, test_skiplist_notifications);
+	add_tcase(s, tc, test_skiplist_search);
 
 /*
  * 	No hashtable_search as it assumes an ordered
  *	collection
  */
-	tc = tcase_create("trie_search");
-	tcase_add_test(tc, test_trie_search);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("skiplist_traverse");
-	tcase_add_test(tc, test_skiplist_traverse);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("hashtable_traverse");
-	tcase_add_test(tc, test_hashtable_traverse);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("trie_traverse");
-	tcase_add_test(tc, test_trie_traverse);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("skiplist_load");
-	tcase_add_test(tc, test_skiplist_load);
-	tcase_set_timeout(tc, 30);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("hashtable_load");
-	tcase_add_test(tc, test_hashtable_load);
-	tcase_set_timeout(tc, 30);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("trie_load");
-	tcase_add_test(tc, test_trie_load);
-	tcase_set_timeout(tc, 30);
-	suite_add_tcase(s, tc);
+	add_tcase(s, tc, test_trie_search);
+	add_tcase(s, tc, test_skiplist_traverse);
+	add_tcase(s, tc, test_hashtable_traverse);
+	add_tcase(s, tc, test_trie_traverse);
+	add_tcase(s, tc, test_skiplist_load, 30);
+	add_tcase(s, tc, test_hashtable_load, 30);
+	add_tcase(s, tc, test_trie_load, 30);
 
 	return s;
 }

--- a/tests/check_rb.c
+++ b/tests/check_rb.c
@@ -25,7 +25,8 @@
 #include <stdlib.h>
 #include <syslog.h>
 #include <errno.h>
-#include <check.h>
+
+#include "check_common.h"
 
 #include <qb/qbdefs.h>
 #include <qb/qbrb.h>
@@ -193,21 +194,10 @@ static Suite *rb_suite(void)
 	TCase *tc;
 	Suite *s = suite_create("ringbuffer");
 
-	tc = tcase_create("test01");
-	tcase_add_test(tc, test_ring_buffer1);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("test02");
-	tcase_add_test(tc, test_ring_buffer2);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("test03");
-	tcase_add_test(tc, test_ring_buffer3);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("test04");
-	tcase_add_test(tc, test_ring_buffer4);
-	suite_add_tcase(s, tc);
+	add_tcase(s, tc, test_ring_buffer1);
+	add_tcase(s, tc, test_ring_buffer2);
+	add_tcase(s, tc, test_ring_buffer3);
+	add_tcase(s, tc, test_ring_buffer4);
 
 	return s;
 }

--- a/tests/check_util.c
+++ b/tests/check_util.c
@@ -22,7 +22,8 @@
  */
 
 #include "os_base.h"
-#include <check.h>
+
+#include "check_common.h"
 
 #include <qb/qbdefs.h>
 #include <qb/qbutil.h>
@@ -159,13 +160,8 @@ static Suite *util_suite(void)
 	TCase *tc;
 	Suite *s = suite_create("qb_util");
 
-	tc = tcase_create("overwrite");
-	tcase_add_test(tc, test_check_overwrite);
-	suite_add_tcase(s, tc);
-
-	tc = tcase_create("normal");
-	tcase_add_test(tc, test_check_normal);
-	suite_add_tcase(s, tc);
+	add_tcase(s, tc, test_check_overwrite);
+	add_tcase(s, tc, test_check_normal);
 
 	return s;
 }


### PR DESCRIPTION
This reduces repeated code significantly, and allows for easier
supervision of what's being grouped to the suites + possibly what
timeouts apply.