### PR TITLE
Add Hurd support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -173,6 +173,18 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
                  )
 
 
+AC_MSG_CHECKING(for a working clock_getres(CLOCK_MONOTONIC, &ts))
+AC_RUN_IFELSE([AC_LANG_PROGRAM(
+[[#include <time.h>]],
+[[struct timespec ts; if(clock_getres(CLOCK_MONOTONIC, &ts)) return -1;]])],
+                    [
+                      AC_MSG_RESULT([yes])
+                      AC_DEFINE_UNQUOTED([HAVE_CLOCK_GETRES_MONOTONIC], 1, [Define to 1 if clock_getres(CLOCK_MONOTONIC, &ts) works])
+                    ],
+                    [
+                      AC_MSG_RESULT([no])
+                    ]
+                 )
 AC_MSG_CHECKING(for MSG_NOSIGNAL)
 AC_TRY_COMPILE([#include <sys/socket.h>],
 	       [ int f = MSG_NOSIGNAL; ],
@@ -334,6 +346,11 @@ case "$host_os" in
 				   [Compiling for Solaris platform])
 		CP=rsync
 		AC_MSG_RESULT([Solaris])
+	;;
+	*gnu*)
+		AC_DEFINE_UNQUOTED([QB_GNU], [1],
+				   [Compiling for GNU/Hurd platform])
+		AC_MSG_RESULT([GNU])
 	;;
 	*)
 		AC_MSG_ERROR([Unsupported OS? hmmmm])

--- a/lib/log_thread.c
+++ b/lib/log_thread.c
@@ -164,7 +164,11 @@ qb_log_thread_start(void)
 
 	if (logt_sched_param_queued) {
 		res = qb_log_thread_priority_set(logt_sched_policy,
+#if defined(HAVE_PTHREAD_SETSCHEDPARAM) && defined(HAVE_SCHED_GET_PRIORITY_MAX)
 		                                 logt_sched_param.sched_priority);
+#else
+		                                 0);
+#endif
 		if (res != 0) {
 			goto cleanup_pthread;
 		}

--- a/lib/util.c
+++ b/lib/util.c
@@ -169,7 +169,12 @@ qb_util_nano_monotonic_hz(void)
 	uint64_t nano_monotonic_hz;
 	struct timespec ts;
 
+#if HAVE_CLOCK_GETRES_MONOTONIC
 	clock_getres(CLOCK_MONOTONIC, &ts);
+#else
+	if (clock_getres(CLOCK_REALTIME, &ts) != 0)
+	    qb_util_perror(LOG_ERR,"CLOCK_REALTIME");
+#endif
 
 	nano_monotonic_hz =
 	    QB_TIME_NS_IN_SEC / ((ts.tv_sec * QB_TIME_NS_IN_SEC) + ts.tv_nsec);


### PR DESCRIPTION
Again (see PR #187, which is superseded with this PR, if I am not mistaken), I am just a messenger.
Original available at [clusterlabs](http://oss.clusterlabs.org/pipermail/developers/2016-March/000164.html) (or [gmane](http://article.gmane.org/gmane.comp.clustering.clusterlabs.devel/125)).

```
  * configure.ac: Define QB_GNU

  * lib/log_thread.c: Replace second argument of
  qb_log_thread_priority_set(): logt_sched_param.sched_priority by 0
  when not supported by the OS.

  * lib/util.c: Fall back to CLOCK_REALTIME in clock_getres() if
    CLOCK_MONOTONIC fails.
```
