### PR TITLE
build: do not install syslog_override for the RPM packaging

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -150,7 +150,7 @@ log_test_LDADD = $(top_builddir)/lib/libqb.la @CHECK_LIBS@
 if HAVE_SYSLOG_TESTS
 log_test_LDADD += _syslog_override.la
 
-lib_LTLIBRARIES = _syslog_override.la
+check_LTLIBRARIES = _syslog_override.la
 _syslog_override_la_SOURCES = _syslog_override.c _syslog_override.h
 _syslog_override_la_LDFLAGS = -module
 endif


### PR DESCRIPTION
The current master branch at https://github.com/ClusterLabs/libqb/commit/043cebb29e08aebd92cf09cea7cb6bc89d940b6e fails to build to `make rpm`.
I assume that the library is necessary only when `make check` and should not be packaged.

```
[root@build-centos71 libqb (master)]# git show --oneline
043cebb Merge pull request #190 from jnpkrn/build-syslog-tests-followup

[root@build-centos71 libqb (master)]# ./autogen.sh && ./configure && make rpm
(snip)
Checking for unpackaged file(s): /usr/lib/rpm/check-files /root/rpmbuild/BUILDROOT/libqb-1.0rc3-1.3.043c.el7.x86_64
error: Installed (but unpackaged) file(s) found:
   /usr/lib64/_syslog_override.so
   /usr/lib64/_syslog_override.so.0
   /usr/lib64/_syslog_override.so.0.0.0


RPM build errors:
    Installed (but unpackaged) file(s) found:
   /usr/lib64/_syslog_override.so
   /usr/lib64/_syslog_override.so.0
   /usr/lib64/_syslog_override.so.0.0.0
make: *** [rpm] Error 1
[root@build-centos71 libqb (master)]# 

```