### PR TITLE
build: fix out-of-tree build broken with 0b04ed5 (#184)

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -45,20 +45,20 @@ doxygen:
 	$(MAKE) -C docs doxygen
 
 dist-clean-local:
-	$(AM_V_GEN)rm -f autoconf automake autoheader
+	rm -f autoconf automake autoheader
 
 maintainer-clean-local:
-	$(AM_V_GEN)rm -rf m4
-	$(AM_V_GEN)rm -f .version .tarball-version
+	rm -rf m4
+	rm -f .version .tarball-version
 
 clean-local:
-	$(AM_V_GEN)rm -rf $(SPEC) $(DIST_ARCHIVES)
+	rm -rf $(SPEC) $(DIST_ARCHIVES)
 
 ## make rpm/srpm section.
 
 $(SPEC): $(SPEC).in
-	$(AM_V_GEN)rm -f $@-t $@
-	date="$(shell LC_ALL=C date "+%a %b %d %Y")" && \
+	@rm -f $@-t $@
+	@date="$(shell LC_ALL=C date "+%a %b %d %Y")" && \
 	if [ -f .tarball-version ]; then \
 		gitver="$(shell cat .tarball-version)" && \
 		rpmver=$$gitver && \
@@ -93,7 +93,7 @@ $(SPEC): $(SPEC).in
 		$< > $@-t; \
 	fi; \
 	if [ -z "$$dirty" ]; then sed -i -e "s#%glo.*dirty.*##g" $@-t; fi
-	$(AM_V_GEN)chmod a-w $@-t
+	@chmod a-w $@-t
 	$(AM_V_GEN)mv $@-t $@
 
 RPMBUILDOPTS	= --define "_sourcedir $(abs_builddir)" \

--- a/Makefile.am
+++ b/Makefile.am
@@ -51,7 +51,7 @@ maintainer-clean-local:
 	$(AM_V_GEN)rm -rf m4
 	$(AM_V_GEN)rm -f .version .tarball-version
 
-clean-generic:
+clean-local:
 	$(AM_V_GEN)rm -rf $(SPEC) $(DIST_ARCHIVES)
 
 ## make rpm/srpm section.

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -49,5 +49,5 @@ doxygen:
 	@echo WARNING: no doxygen to build man pages!
 endif
 
-clean-generic:
+clean-local:
 	rm -rf html man3

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -30,12 +30,13 @@ dependent_headers = $(subst $(inc_dir),,$(shell \
 	| ${MAKE} --no-print-directory -f - inst_HEADERS.var \
 	|| echo $(inc_dir)/qb*.h))
 dependent_headers_omit = qbconfig.h
+dependent_headers_pick = $(filter-out \
+			     $(dependent_headers_omit),$(dependent_headers) \
+			 )
 
-dist_man3_MANS = $(patsubst %,man3/%.3,$(filter-out \
-		     $(dependent_headers_omit),$(dependent_headers) \
-		 ))
+dist_man3_MANS = $(patsubst %,man3/%.3,$(dependent_headers_pick))
 
-$(dist_man3_MANS): man.dox $(dependent_headers:%=$(inc_dir)/%)
+$(dist_man3_MANS): man.dox $(dependent_headers_pick:%=$(inc_dir)/%)
 	mkdir -p man3
 	doxygen man.dox
 

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -24,19 +24,16 @@ noinst_HEADERS          = mainpage.h
 dist_man_MANS = man8/qb-blackbox.8
 if HAVE_DOXYGEN
 inc_dir = $(top_srcdir)/include/qb
-
-dependent_headers = $(subst $(inc_dir),,$(shell \
+public_headers = $(sort $(patsubst %.in,%,$(subst $(inc_dir)/,,$(shell \
 	printf 'include $(inc_dir)/Makefile.am\n\n%%.var:\n\t@echo $$($$*)' \
-	| ${MAKE} --no-print-directory -f - inst_HEADERS.var \
-	|| echo $(inc_dir)/qb*.h))
-dependent_headers_omit = qbconfig.h
-dependent_headers_pick = $(filter-out \
-			     $(dependent_headers_omit),$(dependent_headers) \
-			 )
+	| ${MAKE} --no-print-directory -f- inst_HEADERS.var \
+	|| echo $(inc_dir)/qb*.h*))))
+public_headers_omit = qbconfig.h
+public_headers_pick = $(filter-out $(public_headers_omit),$(public_headers) )
 
-dist_man3_MANS = $(patsubst %,man3/%.3,$(dependent_headers_pick))
+dist_man3_MANS = $(patsubst %,man3/%.3,$(public_headers_pick))
 
-$(dist_man3_MANS): man.dox $(dependent_headers_pick:%=$(inc_dir)/%)
+$(dist_man3_MANS): man.dox $(public_headers_pick:%=$(inc_dir)/%)
 	mkdir -p man3
 	doxygen man.dox
 

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -24,4 +24,3 @@ EXTRA_DIST 		= $(noinst_HEADERS)
 noinst_HEADERS          = os_base.h tlist.h
 
 SUBDIRS			= qb
-

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -81,6 +81,6 @@ run_splint.sh: $(top_srcdir)/configure.ac
 dist-clean-local:
 	$(AM_V_GEN)rm -f run_splint.sh
 
-clean-generic:
+clean-local:
 	$(AM_V_GEN)rm -f run_splint.sh
 endif

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -75,12 +75,12 @@ ALL_LINT_FLAGS = $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(DEB_INCLUDES) \
 		 $(LINT_FLAGS)
 
 run_splint.sh: $(top_srcdir)/configure.ac
-	echo "$(SPLINT) $(ALL_LINT_FLAGS) $(addprefix $(top_srcdir)/lib/, $(source_to_lint))" > $@
+	@echo "$(SPLINT) $(ALL_LINT_FLAGS) $(addprefix $(top_srcdir)/lib/, $(source_to_lint))" > $@
 	$(AM_V_GEN)chmod +x $@
 
 dist-clean-local:
-	$(AM_V_GEN)rm -f run_splint.sh
+	rm -f run_splint.sh
 
 clean-local:
-	$(AM_V_GEN)rm -f run_splint.sh
+	rm -f run_splint.sh
 endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -151,6 +151,6 @@ util_test_LDADD = $(top_builddir)/lib/libqb.la @CHECK_LIBS@
 
 endif
 
-clean-generic:
+clean-local:
 	$(AM_V_GEN)rm -f *.log
 	$(AM_V_GEN)rm -f *.fdata

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -69,8 +69,11 @@ auto_check_header_%.c: $(top_builddir)/include/qb/%.h
 	echo "int main(void) {return 0;}" >> $@_
 	$(AM_V_GEN)mv $@_ $@
 
+check: check-headers
+
 # rely on implicit automake rule to include right (local) includes
-check: $(auto_c_files:.c=.o)
+.PHONY: check-headers
+check-headers: $(auto_c_files:.c=.o)
 
 distclean-compile:
 	rm -rf auto_*.c

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -56,21 +56,11 @@ auto_c_files = $(patsubst %.h,auto_check_header_%.c,$(public_headers))
 CLEANFILES += $(auto_c_files)
 MAINTAINERCLEANFILES += $(auto_c_files)
 
-#
-# The qbconfig.h file is generated from qbconfig.h.in into the build directory tree.
-# We have to have a separate rule for generating the auto_check_header_ source here.
-#
-$(builddir)/auto_check_header_qbconfig.c: $(top_builddir)/include/qb/qbconfig.h
-	@name=$$(echo "$<" | sed  "s|.*qb/qb||" | sed "s|\.h||") ;\
-	NAME=$$(echo $$name | tr [:lower:] [:upper:]) ;\
-	echo "#include <qb/qb$$name.h>" > $@_ ;\
-	echo "#ifndef QB_$${NAME}_H_DEFINED" >> $@_ ;\
-	echo "#error no header protector in file qb$$name.h" >> $@_ ;\
-	echo "#endif" >> $@_ ;\
-	echo "int main(void) {return 0;}" >> $@_
-	$(AM_V_GEN)mv $@_ $@
-
-$(builddir)/auto_check_header_%.c: $(top_srcdir)/include/qb/%.h
+# this works for both non/generated headers thanks to VPATH being
+# automatically set to $(top_srcdir)/tests and $(top_builddir)
+# being resolved to ".." by automake
+# ($(top_srcdir)/tests/../include/qb/%.h = $(top_srcdir)/include/qb/%.h)
+$(builddir)/auto_check_header_%.c: $(top_builddir)/include/qb/%.h
 	@name=$$(echo "$<" | sed  "s|.*qb/qb||" | sed "s|\.h||") ;\
 	NAME=$$(echo $$name | tr [:lower:] [:upper:]) ;\
 	echo "#include <qb/qb$$name.h>" > $@_ ;\

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -22,12 +22,8 @@ EXTRA_DIST =
 CLEANFILES =
 AM_CPPFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include
 
-noinst_PROGRAMS = bmc bmcpt bms rbwriter rbreader loop bench-log \
-	auto_check_header_qbarray auto_check_header_qbconfig auto_check_header_qbhdb \
-	auto_check_header_qbipc_common auto_check_header_qblist auto_check_header_qbloop \
-	auto_check_header_qbrb auto_check_header_qbatomic auto_check_header_qbdefs \
-	auto_check_header_qbipcc auto_check_header_qbipcs auto_check_header_qblog \
-	auto_check_header_qbmap auto_check_header_qbutil format_compare_speed
+noinst_PROGRAMS = bmc bmcpt bms rbreader rbwriter \
+	bench-log format_compare_speed loop
 
 format_compare_speed_SOURCES = format_compare_speed.c $(top_builddir)/include/qb/qbutil.h
 format_compare_speed_LDADD = $(top_builddir)/lib/libqb.la
@@ -51,16 +47,19 @@ rbreader_LDADD = $(top_builddir)/lib/libqb.la
 loop_SOURCES = loop.c $(top_builddir)/include/qb/qbloop.h
 loop_LDADD = $(top_builddir)/lib/libqb.la
 
-public_headers = $(wildcard $(top_srcdir)/include/qb/qb*.h)
+inc_dir = $(top_srcdir)/include/qb
+public_headers = $(sort $(patsubst %.in,%,$(subst $(inc_dir)/,,$(shell \
+	printf 'include $(inc_dir)/Makefile.am\n\n%%.var:\n\t@echo $$($$*)' \
+	| ${MAKE} --no-print-directory -f- inst_HEADERS.var \
+	|| echo $(inc_dir)/qb*.h*))))
 auto_c_files = $(patsubst %.h,auto_check_header_%.c,$(public_headers))
 CLEANFILES += $(auto_c_files)
-MAINTAINERCLEANFILES += $(auto_c_files)
 
 # this works for both non/generated headers thanks to VPATH being
 # automatically set to $(top_srcdir)/tests and $(top_builddir)
 # being resolved to ".." by automake
 # ($(top_srcdir)/tests/../include/qb/%.h = $(top_srcdir)/include/qb/%.h)
-$(builddir)/auto_check_header_%.c: $(top_builddir)/include/qb/%.h
+auto_check_header_%.c: $(top_builddir)/include/qb/%.h
 	@name=$$(echo "$<" | sed  "s|.*qb/qb||" | sed "s|\.h||") ;\
 	NAME=$$(echo $$name | tr [:lower:] [:upper:]) ;\
 	echo "#include <qb/qb$$name.h>" > $@_ ;\
@@ -69,6 +68,9 @@ $(builddir)/auto_check_header_%.c: $(top_builddir)/include/qb/%.h
 	echo "#endif" >> $@_ ;\
 	echo "int main(void) {return 0;}" >> $@_
 	$(AM_V_GEN)mv $@_ $@
+
+# rely on implicit automake rule to include right (local) includes
+check: $(auto_c_files:.c=.o)
 
 distclean-compile:
 	rm -rf auto_*.c

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -85,7 +85,7 @@ nodist_bench_log_SOURCES = auto_write_logs.c
 
 bench_log: auto_write_logs.c
 $(builddir)/auto_write_logs.c: make-log-test.sh
-	$(srcdir)/make-log-test.sh > $(builddir)/write_logs-tmp.c
+	@$(srcdir)/make-log-test.sh > $(builddir)/write_logs-tmp.c
 	$(AM_V_GEN)mv $(builddir)/write_logs-tmp.c $(builddir)/auto_write_logs.c
 endif
 endif
@@ -154,5 +154,5 @@ util_test_LDADD = $(top_builddir)/lib/libqb.la @CHECK_LIBS@
 endif
 
 clean-local:
-	$(AM_V_GEN)rm -f *.log
-	$(AM_V_GEN)rm -f *.fdata
+	rm -f *.log
+	rm -f *.fdata


### PR DESCRIPTION
Generating the man pages definitely doesn't depend on existence of
(possibly generated) header files that we omit anyway.