### PR TITLE
CI: "make check" already included in "make distcheck"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,8 @@ addons:
                   - rpm
 script: RPMBUILDOPTS_="--nodeps --define '_without_check 1'";
         ./autogen.sh
-        && ./configure --enable-syslog-tests
-        && make check
-        && make distcheck
+        && ./configure
+        && DISTCHECK_CONFIGURE_FLAGS=--enable-syslog-tests make distcheck
         && sed "s|RPMBUILDOPTS =|\\0 ${RPMBUILDOPTS_}|" Makefile | make -f- rpm
 sudo: false
 


### PR DESCRIPTION
No need to waste time on redundant tests execution.