### PR TITLE
API: introduce alternative, header-based versioning

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -60,16 +60,20 @@ $(SPEC): $(SPEC).in
 	@rm -f $@-t $@
 	@date="$(shell LC_ALL=C date "+%a %b %d %Y")" && \
 	if [ -f .tarball-version ]; then \
-		gitver="$(shell cat .tarball-version)" && \
+		ver="$(shell cat .tarball-version)" && \
+		gitver=`echo $$ver | sed \
+			-e 's|^\(v[0-9][0-9]*\.[0-9][0-9]*\)\([^.].*\)\?$$|\1.0\2|'` && \
 		rpmver=$$gitver && \
 		alphatag="" && \
 		dirty="" && \
 		numcomm="0"; \
 	else \
-		gitver="$(shell git describe --abbrev=4 --match='v*' --tags HEAD 2>/dev/null)" && \
+		ver="$(shell git describe --abbrev=4 --match='v*' --tags HEAD 2>/dev/null)" && \
+		gitver=`echo $$ver | sed \
+			-e 's|^\(v[0-9][0-9]*\.[0-9][0-9]*\)\([^.].*\)\?$$|\1.0\2|'` && \
 		rpmver=`echo $$gitver | sed -e "s/^v//" -e "s/-.*//g"` && \
 		alphatag=`echo $$gitver | sed -e "s/.*-//" -e "s/^g//"` && \
-		vtag=`echo $$gitver | sed -e "s/-.*//g"` && \
+		vtag=`echo $$ver | sed -e "s/-.*//g"` && \
 		numcomm=`git rev-list $$vtag..HEAD | wc -l` && \
 		git update-index --refresh > /dev/null 2>&1 || true && \
 		dirty=`git diff-index --name-only HEAD 2>/dev/null`; \

--- a/configure.ac
+++ b/configure.ac
@@ -612,6 +612,28 @@ AC_DEFINE_UNQUOTED([SOCKETDIR], "$(eval echo ${SOCKETDIR})", [Socket directory])
 AC_DEFINE_UNQUOTED([LOCALSTATEDIR], "$(eval echo ${localstatedir})", [localstate directory])
 AC_DEFINE_UNQUOTED([PACKAGE_FEATURES], "${PACKAGE_FEATURES}", [quarterback built-in features])
 
+# version parsing (for qbconfig.h)
+AC_DEFINE_UNQUOTED([QB_VER_MAJOR],
+                   [$(echo "${VERSION}" \
+		      | sed -e 's|^\([[0-9]][[0-9]]*\).*|\1|' \
+		            -e t -e 's|.*|1|')],
+		   [libqb major version])
+AC_DEFINE_UNQUOTED([QB_VER_MINOR],
+                   [$(echo "${VERSION}" \
+		      | sed -e 's|^[[0-9]][[0-9]]*\.\([[0-9]][[0-9]]*\).*|\1|' \
+		            -e t -e 's|.*|0|')],
+		   [libqb minor version])
+AC_DEFINE_UNQUOTED([QB_VER_PATCH],
+	           [$(echo "${VERSION}" \
+		      | sed -e 's|^[[0-9]][[0-9]]*\.[[0-9]][[0-9]]*\.\([[0-9]][[0-9]]*\).*|\1|' \
+		            -e t -e 's|.*|0|')],
+		   [libqb patch version])
+AC_DEFINE_UNQUOTED([QB_VER_REST],
+	           [$(echo "${VERSION}" \
+		      | sed -e 's|^[[0-9]][[0-9]]*\(\.[[0-9]][[0-9]]*\)\{0,2\}\(.*\)|"\2"|' \
+		            -e t -e 's|.*|""|')],
+		   [libqb patch version])
+
 AC_CONFIG_FILES([Makefile
 		 include/Makefile
 		 include/qb/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -3,8 +3,10 @@
 
 AC_PREREQ([2.61])
 
+dnl inject zero as a "patch" component of the version if missing in tag
 AC_INIT([libqb],
-	m4_esyscmd([build-aux/git-version-gen .tarball-version]),
+	m4_esyscmd([build-aux/git-version-gen .tarball-version \
+		    's|^\(v[0-9][0-9]*\.[0-9][0-9]*\)\([^.].*\)\?$|\1.0\2|']),
 	[developers@clusterlabs.org])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_SRCDIR([lib/ringbuffer.c])

--- a/include/qb/qbconfig.h.in
+++ b/include/qb/qbconfig.h.in
@@ -22,10 +22,26 @@
 #ifndef QB_CONFIG_H_DEFINED
 #define QB_CONFIG_H_DEFINED
 
+#include <qb/qbdefs.h>  /* QB_PP_STRINGIFY */
+
 /* need atomic memory barrier */
 #undef QB_ATOMIC_OP_MEMORY_BARRIER_NEEDED
 
 /* Enabling code using __attribute__((section)) */
 #undef QB_HAVE_ATTRIBUTE_SECTION
+
+/* versioning info: MAJOR, MINOR, PATCH, and REST components */
+#undef QB_VER_MAJOR
+#undef QB_VER_MINOR
+#undef QB_VER_PATCH
+#undef QB_VER_REST
+
+#define QB_VER_STR   \
+	QB_PP_STRINGIFY(QB_VER_MAJOR) \
+	"." \
+	QB_PP_STRINGIFY(QB_VER_MINOR) \
+	"." \
+	QB_PP_STRINGIFY(QB_VER_PATCH) \
+	QB_VER_REST
 
 #endif /* QB_CONFIG_H_DEFINED */

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -13,3 +13,4 @@ format_compare_speed
 crash_test_dummy
 file_change_bytes
 test.conf
+print_ver

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -23,7 +23,7 @@ CLEANFILES =
 AM_CPPFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include
 
 noinst_PROGRAMS = bmc bmcpt bms rbreader rbwriter \
-	bench-log format_compare_speed loop
+	bench-log format_compare_speed loop print_ver
 
 noinst_HEADERS = check_common.h
 

--- a/tests/print_ver.c
+++ b/tests/print_ver.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016 Red Hat, Inc.
+ *
+ * All rights reserved.
+ *
+ * Author: Jan Pokorny <jpokorny@redhat.com>
+ *
+ * This file is part of libqb.
+ *
+ * libqb is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * libqb is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with libqb.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "os_base.h"  /* instead of assert.h & stdio.h + defines VERSION */
+
+#include <qb/qbconfig.h>  /* QB_VER_{MAJOR,MINOR,PATCH,REST} + QB_VER_STR */
+#include <qb/qbdefs.h>  /* QB_PP_STRINGIFY */
+
+int
+main(void)
+{
+	printf("%s consists of: %d, %d, %d, %s\n", QB_VER_STR,
+	       QB_VER_MAJOR, QB_VER_MINOR, QB_VER_PATCH, QB_VER_REST);
+	return 0;
+}
+
+/* make version components emitted during "make check" for easy inspection;
+   semicolon intentionally omitted so as to avoid unnecessary message
+   source diagnostics (bug or feature?) with some GCC versions (5.3.1) */
+#define MSG QB_PP_STRINGIFY( \
+	GCC warning QB_PP_STRINGIFY(VERSION parsed as: QB_VER_STR))
+_Pragma(MSG)


### PR DESCRIPTION
Mainly as a light-weight alternative to full-blown autoconf/pkg-config
machineries, whereby one can:

* workaround functionality not present in libqb up to 1.0 (inclusive)
  - note that this versioning schema is being introduced *after*
    1.0.0 release so one cannot tell that version from any older,
    but will be able to safely identify any later one (1.0.1+)
    and act accordingly
  - example:
  #if !defined(QB_VER_MAJOR) || ((QB_VER_MAJOR == 1) && (QB_VER_MINOR < 1))
  #warning "Feature X not supported"
  int do_foo(int arg) { };
  #else
  int
  do_foo(int arg)
  {
      /* use feature X of libqb */
  }
  #endif

* make its program report libqb API version it was built with by
  emitting QB_VER_STR symblic string (see tests/print_ver.c for example)

Also added is a print_ver test program to:

* emit how original unparsed version is parsed to particular components
  defined in qbconfig.h (QB_VER_{MAJOR,MINOR,PATCH} symbolic integer
  constants and QB_VER_REST symbolic string) when being compiled

* emit mentioned QB_VER_STR symbolic string joining the components
  back to a single string, plus the components themselves

Resolves: https://github.com/ClusterLabs/libqb/issues/186