### PR TITLE
API: header-based versioning: s/PATCH/MICRO

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -625,7 +625,7 @@ AC_DEFINE_UNQUOTED([QB_VER_MINOR],
 		      | sed -e 's|^[[0-9]][[0-9]]*\.\([[0-9]][[0-9]]*\).*|\1|' \
 		            -e t -e 's|.*|0|')],
 		   [libqb minor version])
-AC_DEFINE_UNQUOTED([QB_VER_PATCH],
+AC_DEFINE_UNQUOTED([QB_VER_MICRO],
 	           [$(echo "${VERSION}" \
 		      | sed -e 's|^[[0-9]][[0-9]]*\.[[0-9]][[0-9]]*\.\([[0-9]][[0-9]]*\).*|\1|' \
 		            -e t -e 's|.*|0|')],

--- a/include/qb/qbconfig.h.in
+++ b/include/qb/qbconfig.h.in
@@ -30,10 +30,10 @@
 /* Enabling code using __attribute__((section)) */
 #undef QB_HAVE_ATTRIBUTE_SECTION
 
-/* versioning info: MAJOR, MINOR, PATCH, and REST components */
+/* versioning info: MAJOR, MINOR, MICRO, and REST components */
 #undef QB_VER_MAJOR
 #undef QB_VER_MINOR
-#undef QB_VER_PATCH
+#undef QB_VER_MICRO
 #undef QB_VER_REST
 
 #define QB_VER_STR   \
@@ -41,7 +41,7 @@
 	"." \
 	QB_PP_STRINGIFY(QB_VER_MINOR) \
 	"." \
-	QB_PP_STRINGIFY(QB_VER_PATCH) \
+	QB_PP_STRINGIFY(QB_VER_MICRO) \
 	QB_VER_REST
 
 #endif /* QB_CONFIG_H_DEFINED */

--- a/tests/print_ver.c
+++ b/tests/print_ver.c
@@ -23,14 +23,14 @@
 
 #include "os_base.h"  /* instead of assert.h & stdio.h + defines VERSION */
 
-#include <qb/qbconfig.h>  /* QB_VER_{MAJOR,MINOR,PATCH,REST} + QB_VER_STR */
+#include <qb/qbconfig.h>  /* QB_VER_{MAJOR,MINOR,MICRO,REST} + QB_VER_STR */
 #include <qb/qbdefs.h>  /* QB_PP_STRINGIFY */
 
 int
 main(void)
 {
 	printf("%s consists of: %d, %d, %d, %s\n", QB_VER_STR,
-	       QB_VER_MAJOR, QB_VER_MINOR, QB_VER_PATCH, QB_VER_REST);
+	       QB_VER_MAJOR, QB_VER_MINOR, QB_VER_MICRO, QB_VER_REST);
 	return 0;
 }
 


### PR DESCRIPTION
Under the influence of libxml2 and considering that actual "patch"
information in fact, if significant, ends up encoded in QB_VER_REST,
shift away from convention codified, e.g., by semver.org (not adored
by libqb, anyway) and rename designated PATCH component of the version
to MICRO accordingly.

Note that at this point, after a release without any header-based
versioning present and just a few commits after it was tentatively
introduced, it's a painless change.  Once this PATCH nomenclature
is leaked into a full release, there's no way to get rid of it
reasonably...