### PR TITLE
CI: make Travis invoke also rpmlint for good measure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,12 @@ compiler:
         - clang
 addons:
         apt:
+                sources:
+                        - debian-sid
                 packages:
                         - check
                         - splint
+                        - rpmlint
                         # for "make rpm"
                         - doxygen
                         - rpm
@@ -15,6 +18,7 @@ script: RPMBUILDOPTS_="--nodeps --define '_without_check 1'";
         && ./configure
         && DISTCHECK_CONFIGURE_FLAGS=--enable-syslog-tests VERBOSE=1 make distcheck
         && sed "s|RPMBUILDOPTS =|\\0 ${RPMBUILDOPTS_}|" Makefile | make -f- rpm
+        && rpmlint -iv libqb.spec
 sudo: false
 
 notifications:


### PR DESCRIPTION
See also container-based infrastructure vs. rpmlint's setuid/setgid:

```
https://github.com/travis-ci/apt-package-whitelist/pull/2109
```
