### PR TITLE
Low: log: check for appropriate space when serializing a char

### DIFF
--- a/lib/log_format.c
+++ b/lib/log_format.c
@@ -604,9 +604,10 @@ reprocess:
 			int arg_int;
 			unsigned char arg_char;
 
-			if (location + sizeof (unsigned int) > max_len) {
+			if (location + sizeof (unsigned char) > max_len) {
 				return max_len;
 			}
+			/* va_arg only takes fully promoted types */
 			arg_int = va_arg(ap, unsigned int);
 			arg_char = (unsigned char)arg_int;
 			memcpy (&serialize[location], &arg_char, sizeof (unsigned char));


### PR DESCRIPTION
... where appropriate space is measured for, surprisingly, a char,
not for an int.  Note that's also the actual type used for both
de-/serializing, so there's no conflict.

Also bother to explain why, now surprisingly for real, an unsigned int
is scraped out from va_list (akin to to STDARG(3)).