### PR TITLE
docs: qbdefs.h: description must directly follow @file

### DIFF
--- a/include/qb/qbdefs.h
+++ b/include/qb/qbdefs.h
@@ -28,9 +28,9 @@ extern "C" {
 
 /**
  * @file qbdefs.h
- * @author Angus Salkeld <asalkeld@redhat.com>
- *
  * These are some convience macros and defines.
+ *
+ * @author Angus Salkeld <asalkeld@redhat.com>
  */
 
 /*


### PR DESCRIPTION
If we want to see it again in the man page NAME section, where it can
be indexed by apropos or whatis.