### PR TITLE
Med: log_thread: logt_wthread_lock is vital for logging thread

### DIFF
--- a/lib/log_thread.c
+++ b/lib/log_thread.c
@@ -62,9 +62,7 @@ qb_logt_worker_thread(void *data)
 	int dropped = 0;
 	int res;
 
-	/*
-	 * Signal wthread_create that the initialization process may continue
-	 */
+	/* Signal qb_log_thread_start that the initialization may continue */
 	sem_post(&logt_thread_start);
 	for (;;) {
 retry_sem_wait:
@@ -72,9 +70,7 @@ retry_sem_wait:
 		if (res == -1 && errno == EINTR) {
 			goto retry_sem_wait;
 		} else if (res == -1) {
-			/*
-			 * This case shouldn't happen
-			 */
+			/* This case shouldn't happen */
 			pthread_exit(NULL);
 		}
 

--- a/tests/check_log.c
+++ b/tests/check_log.c
@@ -726,6 +726,42 @@ START_TEST(test_threaded_logging)
 }
 END_TEST
 
+#ifdef HAVE_PTHREAD_SETSCHEDPARAM
+START_TEST(test_threaded_logging_bad_sched_params)
+{
+	int32_t t;
+	int32_t rc;
+
+	qb_log_init("test", LOG_USER, LOG_EMERG);
+	qb_log_ctl(QB_LOG_SYSLOG, QB_LOG_CONF_ENABLED, QB_FALSE);
+
+	t = qb_log_custom_open(_test_logger, NULL, NULL, NULL);
+	rc = qb_log_filter_ctl(t, QB_LOG_FILTER_ADD,
+			       QB_LOG_FILTER_FILE, "*", LOG_INFO);
+	ck_assert_int_eq(rc, 0);
+	qb_log_format_set(t, "%b");
+	rc = qb_log_ctl(t, QB_LOG_CONF_ENABLED, QB_TRUE);
+	ck_assert_int_eq(rc, 0);
+	rc = qb_log_ctl(t, QB_LOG_CONF_THREADED, QB_TRUE);
+	ck_assert_int_eq(rc, 0);
+
+#if defined(SCHED_RR)
+#define QB_SCHED SCHED_RR
+#elif defined(SCHED_FIFO)
+#define QB_SCHED SCHED_FIFO
+#else
+#define QB_SCHED (-1)
+#endif
+	rc = qb_log_thread_priority_set(QB_SCHED, -1);
+	ck_assert_int_eq(rc, 0);
+
+	rc = qb_log_thread_start();
+	ck_assert_int_ne(rc, 0);
+	qb_log_fini();
+}
+END_TEST
+#endif
+
 START_TEST(test_extended_information)
 {
 	int32_t t;
@@ -817,6 +853,9 @@ log_suite(void)
 	add_tcase(s, tc, test_log_long_msg);
 	add_tcase(s, tc, test_log_filter_fn);
 	add_tcase(s, tc, test_threaded_logging);
+#ifdef HAVE_PTHREAD_SETSCHEDPARAM
+	add_tcase(s, tc, test_threaded_logging_bad_sched_params);
+#endif
 	add_tcase(s, tc, test_extended_information);
 
 #ifdef HAVE_SYSLOG_TESTS


### PR DESCRIPTION
This fixes issue with would-fail-if-applied-to-thread-right-away
qb_log_thread_priority_set invocation when logging thread doesn't
exist yet, which will arrange for calling itself at the time of
thread's birth that is the moment it will actually fail.
In this + lock-could-not-have-been-initialized corner cases, the
already running thread would proceed as allowed by error condition
handling in the main thread, trying to dereference uninitialized
(or outdated) pointer to the lock at hand, resulting in segfault.

Also include the test that would have been caught that (we use the
fact that it doesn't matter whether setting of the scheduler parameters
fails due to bad input or just because of lack of privileges as it's
the failure at the right moment that is of our interest).

See also:
https://github.com/ClusterLabs/libqb/issues/229