### PR TITLE
Allow compile-time configuration of filesystem sockets for Linux

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -324,6 +324,7 @@ case "$host_os" in
 		AC_DEFINE_UNQUOTED([QB_LINUX], [1],
 				   [Compiling for Linux platform])
 		AC_MSG_RESULT([Linux])
+    		AC_DEFINE_UNQUOTED([QB_ABSTRACT_SOCKETS],[1], [use Linux abstract sockets])
 	;;
 	*cygwin*)
 		AC_DEFINE_UNQUOTED([QB_CYGWIN], [1],
@@ -332,6 +333,7 @@ case "$host_os" in
 		nongcc_memory_barrier_needed=yes
 		gcc_has_builtin_sync_operations=no
 		AC_MSG_RESULT([Cygwin])
+    		AC_DEFINE_UNQUOTED([QB_ABSTRACT_SOCKETS],[1], [use Linux abstract sockets])
 	;;
 	darwin*)
 		AC_DEFINE_UNQUOTED([QB_DARWIN], [1],
@@ -473,6 +475,10 @@ AC_ARG_ENABLE([coverage],
 
 AC_ARG_ENABLE([slow-tests],
   [AS_HELP_STRING([--enable-slow-tests],[build and run slow tests])])
+
+AC_ARG_ENABLE([filesystem-sockets],
+  [AS_HELP_STRING([--enable-filesysten-sockets], [use filesystem sockets on Linux/Cygwin])],
+        AC_DEFINE_UNQUOTED([QB_ABSTRACT_SOCKETS],[0], [use Linux abstract sockets]))
 
 AC_ARG_WITH([socket-dir],
   [AS_HELP_STRING([--with-socket-dir=DIR],[socket directory @<:@LOCALSTATEDIR/run@:>@])],

--- a/configure.ac
+++ b/configure.ac
@@ -477,7 +477,7 @@ AC_ARG_ENABLE([slow-tests],
   [AS_HELP_STRING([--enable-slow-tests],[build and run slow tests])])
 
 AC_ARG_ENABLE([filesystem-sockets],
-  [AS_HELP_STRING([--enable-filesysten-sockets], [use filesystem sockets on Linux/Cygwin])],
+  [AS_HELP_STRING([--enable-filesystem-sockets], [use filesystem sockets on Linux/Cygwin])],
         AC_DEFINE_UNQUOTED([QB_ABSTRACT_SOCKETS],[0], [use Linux abstract sockets]))
 
 AC_ARG_WITH([socket-dir],

--- a/lib/ipc_setup.c
+++ b/lib/ipc_setup.c
@@ -286,7 +286,7 @@ qb_ipcc_stream_sock_connect(const char *socket_name, int32_t * sock_pt)
 	address.sun_len = QB_SUN_LEN(&address);
 #endif
 
-#if defined(QB_LINUX) || defined(QB_CYGWIN)
+#if defined(QB_ABSTRACT_SOCKETS) && QB_ABSTRACT_SOCKETS==1
 	snprintf(address.sun_path + 1, UNIX_PATH_MAX - 1, "%s", socket_name);
 #else
 	snprintf(address.sun_path, sizeof(address.sun_path), "%s/%s", SOCKETDIR,
@@ -535,7 +535,7 @@ qb_ipcs_us_publish(struct qb_ipcs_service * s)
 #endif
 
 	qb_util_log(LOG_INFO, "server name: %s", s->name);
-#if defined(QB_LINUX) || defined(QB_CYGWIN)
+#if defined(QB_ABSTRACT_SOCKETS) && QB_ABSTRACT_SOCKETS==1
 	snprintf(un_addr.sun_path + 1, UNIX_PATH_MAX - 1, "%s", s->name);
 #else
 	{
@@ -567,7 +567,7 @@ qb_ipcs_us_publish(struct qb_ipcs_service * s)
 	 * Allow everyone to write to the socket since the IPC layer handles
 	 * security automatically
 	 */
-#if !defined(QB_LINUX) && !defined(QB_CYGWIN)
+#if !defined(QB_ABSTRACT_SOCKETS) || QB_ABSTRACT_SOCKETS==0
 	res = chmod(un_addr.sun_path, S_IRWXU | S_IRWXG | S_IRWXO);
 #endif
 #ifdef SO_PASSCRED

--- a/lib/ipc_setup.c
+++ b/lib/ipc_setup.c
@@ -594,14 +594,13 @@ qb_ipcs_us_withdraw(struct qb_ipcs_service * s)
 	struct sockaddr_un sockname;
 	socklen_t socklen = sizeof(sockname);
 #endif
-	int res;
 
 	qb_util_log(LOG_INFO, "withdrawing server sockets");
 	(void)s->poll_fns.dispatch_del(s->server_sock);
 	shutdown(s->server_sock, SHUT_RDWR);
 
 #if !defined(QB_ABSTRACT_SOCKETS) || QB_ABSTRACT_SOCKETS==0
-	if ((getsockname(s->server_sock, &sockname, &socklen) == 0) &&
+	if ((getsockname(s->server_sock, (struct sockaddr *)&sockname, &socklen) == 0) &&
 	    sockname.sun_family == AF_LOCAL) {
 		unlink(sockname.sun_path);
 	}


### PR DESCRIPTION
Allow Linux users the option (at ./configure time) of abstract or filesystem sockets. While abstract sockets can be tidier (and get cleaned up automatically at process end), on some container systems the namespace is global, preventing multiple instances of the same application from running. This system also allows programs to communicate between containers (by sharing a filesystem) should that be needed.
