### PR TITLE
Allow Linux to use filesystem sockets

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -480,9 +480,9 @@ AC_ARG_WITH([socket-dir],
 	[ SOCKETDIR="$localstatedir/run" ])
 
 AC_ARG_WITH([force-sockets-config-file],
-  [AS_HELP_STRING([--with-force-sockets-config-file=FILE],[config file to force filesystem sockets directory @<:@SYSCONFDIR/.libqb.enable.filesystem.sockets@:>@])],
+  [AS_HELP_STRING([--with-force-sockets-config-file=FILE],[config file to force IPC to use filesystem sockets (Linux & Cygwin only) @<:@SYSCONFDIR/libqb/force-filesystem-sockets@:>@])],
 	[ FORCESOCKETSFILE="$withval" ],
-	[ FORCESOCKETSFILE="$sysconfdir/.libqb.enable.filesystem.sockets" ])
+	[ FORCESOCKETSFILE="$sysconfdir/libqb/force-filesystem-sockets" ])
 
 AC_SUBST(CP)
 # *FLAGS handling goes here

--- a/configure.ac
+++ b/configure.ac
@@ -479,6 +479,11 @@ AC_ARG_WITH([socket-dir],
 	[ SOCKETDIR="$withval" ],
 	[ SOCKETDIR="$localstatedir/run" ])
 
+AC_ARG_WITH([force-sockets-config-file],
+  [AS_HELP_STRING([--with-force-sockets-config-file=FILE],[config file to force filesystem sockets directory @<:@SYSCONFDIR/.libqb.enable.filesystem.sockets@:>@])],
+	[ FORCESOCKETSFILE="$withval" ],
+	[ FORCESOCKETSFILE="$sysconfdir/.libqb.enable.filesystem.sockets" ])
+
 AC_SUBST(CP)
 # *FLAGS handling goes here
 
@@ -634,10 +639,13 @@ AM_CONDITIONAL([HAVE_DICT_WORDS], [test "x$HAVE_DICT_WORDS" = xyes])
 # substitute what we need:
 AC_SUBST([SOCKETDIR])
 AC_SUBST([LINT_FLAGS])
+AC_SUBST([FORCESOCKETSFILE])
 
 AC_DEFINE_UNQUOTED([SOCKETDIR], "$(eval echo ${SOCKETDIR})", [Socket directory])
 AC_DEFINE_UNQUOTED([LOCALSTATEDIR], "$(eval echo ${localstatedir})", [localstate directory])
 AC_DEFINE_UNQUOTED([PACKAGE_FEATURES], "${PACKAGE_FEATURES}", [quarterback built-in features])
+
+AC_DEFINE_UNQUOTED([FORCESOCKETSFILE], "$(eval echo ${FORCESOCKETSFILE})", [for sockets config file])
 
 # version parsing (for qbconfig.h)
 AC_DEFINE_UNQUOTED([QB_VER_MAJOR],

--- a/docs/mainpage.h
+++ b/docs/mainpage.h
@@ -101,6 +101,19 @@
  * a single one pushed throughout its lifecycle just with a single thread;
  * anything else would likely warrant external synchronization enforcement.
  *
+ * @par IPC sockets (Linux only)
+ * On Linux IPC, abstract (non-filesystem) sockets are used by default. If you
+ * need to override this (say in a net=host container) and use sockets that reside
+ * in the filesystem, then create a file called /etc/libqb/force-filesystem-sockets
+ * - this is the default name and can be changed at ./configure time.
+ * The file need contain no text, it's not a configuration file as such, just its
+ * presence will activate the feature.
+ *
+ * Note that this is a global option and read each time a new IPC connection
+ * (client or server) is created. So, to avoid having clients that cannot
+ * connect to running servers it is STRONGLY recommended to only create or remove
+ * this file prior to a system reboot or container restart.
+ *
  * @par Client API
  * @copydoc qbipcc.h
  * @see qbipcc.h

--- a/lib/ipc_int.h
+++ b/lib/ipc_int.h
@@ -205,4 +205,6 @@ int32_t qb_ipcs_process_request(struct qb_ipcs_service *s,
 
 int32_t qb_ipc_us_sock_error_is_disconnected(int err);
 
+int use_filesystem_sockets(void);
+
 #endif /* QB_IPC_INT_H_DEFINED */

--- a/lib/ipc_setup.c
+++ b/lib/ipc_setup.c
@@ -598,7 +598,7 @@ qb_ipcs_us_withdraw(struct qb_ipcs_service * s)
 		struct sockaddr_un sockname;
 		socklen_t socklen = sizeof(sockname);
 		if ((getsockname(s->server_sock, (struct sockaddr *)&sockname, &socklen) == 0) &&
-		    sockname.sun_family == AF_LOCAL) {
+		    sockname.sun_family == AF_UNIX) {
 			unlink(sockname.sun_path);
 		}
 	}

--- a/lib/ipc_socket.c
+++ b/lib/ipc_socket.c
@@ -41,27 +41,25 @@ struct ipc_us_control {
 	int32_t flow_control;
 };
 #define SHM_CONTROL_SIZE (3 * sizeof(struct ipc_us_control))
-int use_filesystem_sockets(void);
 
 int use_filesystem_sockets(void)
 {
-    static int need_init = 1;
-    static int filesystem_sockets = 0;
+	static int need_init = 1;
+	static int filesystem_sockets = 0;
 
-    if(need_init) {
-        struct stat buf;
+	if (need_init) {
+		struct stat buf;
 
-        need_init = 0;
+		need_init = 0;
 #if defined(QB_LINUX) || defined(QB_CYGWIN)
-        if(stat(FORCESOCKETSFILE, &buf) == 0) {
-            filesystem_sockets = 1;
-        }
+		if (stat(FORCESOCKETSFILE, &buf) == 0) {
+			filesystem_sockets = 1;
+		}
 #else
-        filesystem_sockets = 1;
+		filesystem_sockets = 1;
 #endif
-    }
-
-    return filesystem_sockets;
+	}
+	return filesystem_sockets;
 }
 
 static void
@@ -73,12 +71,12 @@ set_sock_addr(struct sockaddr_un *address, const char *socket_name)
 	address->sun_len = QB_SUN_LEN(address);
 #endif
 
-        if(use_filesystem_sockets() == 0) {
-	snprintf(address->sun_path + 1, UNIX_PATH_MAX - 1, "%s", socket_name);
-        } else {
-	snprintf(address->sun_path, sizeof(address->sun_path), "%s/%s", SOCKETDIR,
-		 socket_name);
-        }
+	if (!use_filesystem_sockets()) {
+		snprintf(address->sun_path + 1, UNIX_PATH_MAX - 1, "%s", socket_name);
+	} else {
+		snprintf(address->sun_path, sizeof(address->sun_path), "%s/%s", SOCKETDIR,
+			 socket_name);
+	}
 }
 
 static int32_t
@@ -103,15 +101,16 @@ qb_ipc_dgram_sock_setup(const char *base_name,
 	}
 	snprintf(sock_path, PATH_MAX, "%s-%s", base_name, service_name);
 	set_sock_addr(&local_address, sock_path);
-        if(use_filesystem_sockets()) {
-	res = unlink(local_address.sun_path);
-        }
+	if (use_filesystem_sockets()) {
+		res = unlink(local_address.sun_path);
+	}
 	res = bind(request_fd, (struct sockaddr *)&local_address,
 		   sizeof(local_address));
-        if(use_filesystem_sockets()) {
-	chmod(local_address.sun_path, 0660);
-	chown(local_address.sun_path, -1, gid);
-        }
+
+	if (use_filesystem_sockets()) {
+		chmod(local_address.sun_path, 0660);
+		chown(local_address.sun_path, -1, gid);
+	}
 	if (res < 0) {
 		goto error_connect;
 	}
@@ -346,30 +345,30 @@ qb_ipcc_us_disconnect(struct qb_ipcc_connection *c)
 	munmap(c->request.u.us.shared_data, SHM_CONTROL_SIZE);
 	unlink(c->request.u.us.shared_file_name);
 
-        if(use_filesystem_sockets()) {
-  struct sockaddr_un un_addr;
-  socklen_t un_addr_len = sizeof(struct sockaddr_un);
-  char *base_name;
-  char sock_name[PATH_MAX];
-  size_t length;
-    if (getsockname(c->response.u.us.sock, (struct sockaddr *)&un_addr, &un_addr_len) == 0) {
-      length = strlen(un_addr.sun_path);
-      base_name = strndup(un_addr.sun_path,length-9);
-      qb_util_log(LOG_DEBUG, "unlinking socket bound files with base_name=%s length=%d",base_name,length);
-      snprintf(sock_name,PATH_MAX,"%s-%s",base_name,"request");
-      qb_util_log(LOG_DEBUG, "unlink sock_name=%s",sock_name);
-      unlink(sock_name);
-      snprintf(sock_name,PATH_MAX,"%s-%s",base_name,"event");
-      qb_util_log(LOG_DEBUG, "unlink sock_name=%s",sock_name);
-      unlink(sock_name);
-      snprintf(sock_name,PATH_MAX,"%s-%s",base_name,"event-tx");
-      qb_util_log(LOG_DEBUG, "unlink sock_name=%s",sock_name);
-      unlink(sock_name);
-      snprintf(sock_name,PATH_MAX,"%s-%s",base_name,"response");
-      qb_util_log(LOG_DEBUG, "unlink sock_name=%s",sock_name);
-      unlink(sock_name);
-    }
-        }
+	if (use_filesystem_sockets()) {
+		struct sockaddr_un un_addr;
+		socklen_t un_addr_len = sizeof(struct sockaddr_un);
+		char *base_name;
+		char sock_name[PATH_MAX];
+		size_t length;
+		if (getsockname(c->response.u.us.sock, (struct sockaddr *)&un_addr, &un_addr_len) == 0) {
+			length = strlen(un_addr.sun_path);
+			base_name = strndup(un_addr.sun_path,length-9);
+			qb_util_log(LOG_DEBUG, "unlinking socket bound files with base_name=%s length=%d",base_name,length);
+			snprintf(sock_name,PATH_MAX,"%s-%s",base_name,"request");
+			qb_util_log(LOG_DEBUG, "unlink sock_name=%s",sock_name);
+			unlink(sock_name);
+			snprintf(sock_name,PATH_MAX,"%s-%s",base_name,"event");
+			qb_util_log(LOG_DEBUG, "unlink sock_name=%s",sock_name);
+			unlink(sock_name);
+			snprintf(sock_name,PATH_MAX,"%s-%s",base_name,"event-tx");
+			qb_util_log(LOG_DEBUG, "unlink sock_name=%s",sock_name);
+			unlink(sock_name);
+			snprintf(sock_name,PATH_MAX,"%s-%s",base_name,"response");
+			qb_util_log(LOG_DEBUG, "unlink sock_name=%s",sock_name);
+			unlink(sock_name);
+		}
+	}
 	qb_ipcc_us_sock_close(c->event.u.us.sock);
 	qb_ipcc_us_sock_close(c->request.u.us.sock);
 	qb_ipcc_us_sock_close(c->setup.u.us.sock);
@@ -475,11 +474,11 @@ retry_peek:
 
 		if (errno != EAGAIN) {
 			final_rc = -errno;
-                        if(use_filesystem_sockets()) {
-			if (errno == ECONNRESET || errno == EPIPE) {
-				final_rc = -ENOTCONN;
+			if (use_filesystem_sockets()) {
+				if (errno == ECONNRESET || errno == EPIPE) {
+					final_rc = -ENOTCONN;
+				}
 			}
-                        }
 			goto cleanup_sigpipe;
 		}
 
@@ -716,30 +715,30 @@ qb_ipcs_us_disconnect(struct qb_ipcs_connection *c)
 	    c->state == QB_IPCS_CONNECTION_ACTIVE) {
 		_sock_rm_from_mainloop(c);
 
-                if(use_filesystem_sockets()) {
-                    struct sockaddr_un un_addr;
-                    socklen_t un_addr_len = sizeof(struct sockaddr_un);
-                    char *base_name;
-                    char sock_name[PATH_MAX];
-                    size_t length;
-		if (getsockname(c->response.u.us.sock, (struct sockaddr *)&un_addr, &un_addr_len) == 0) {
-			length = strlen(un_addr.sun_path);
-			base_name = strndup(un_addr.sun_path,length-8);
-			qb_util_log(LOG_DEBUG, "unlinking socket bound files with base_name=%s length=%d",base_name,length);
-			snprintf(sock_name,PATH_MAX,"%s-%s",base_name,"request");
-			qb_util_log(LOG_DEBUG, "unlink sock_name=%s",sock_name);
-			unlink(sock_name);
-			snprintf(sock_name,PATH_MAX,"%s-%s",base_name,"event");
-			qb_util_log(LOG_DEBUG, "unlink sock_name=%s",sock_name);
-			unlink(sock_name);
-			snprintf(sock_name,PATH_MAX,"%s-%s",base_name,"event-tx");
-			qb_util_log(LOG_DEBUG, "unlink sock_name=%s",sock_name);
-			unlink(sock_name);
-			snprintf(sock_name,PATH_MAX,"%s-%s",base_name,"response");
-			qb_util_log(LOG_DEBUG, "unlink sock_name=%s",sock_name);
-			unlink(sock_name);
+		if (use_filesystem_sockets()) {
+			struct sockaddr_un un_addr;
+			socklen_t un_addr_len = sizeof(struct sockaddr_un);
+			char *base_name;
+			char sock_name[PATH_MAX];
+			size_t length;
+			if (getsockname(c->response.u.us.sock, (struct sockaddr *)&un_addr, &un_addr_len) == 0) {
+				length = strlen(un_addr.sun_path);
+				base_name = strndup(un_addr.sun_path,length-8);
+				qb_util_log(LOG_DEBUG, "unlinking socket bound files with base_name=%s length=%d",base_name,length);
+				snprintf(sock_name,PATH_MAX,"%s-%s",base_name,"request");
+				qb_util_log(LOG_DEBUG, "unlink sock_name=%s",sock_name);
+				unlink(sock_name);
+				snprintf(sock_name,PATH_MAX,"%s-%s",base_name,"event");
+				qb_util_log(LOG_DEBUG, "unlink sock_name=%s",sock_name);
+				unlink(sock_name);
+				snprintf(sock_name,PATH_MAX,"%s-%s",base_name,"event-tx");
+				qb_util_log(LOG_DEBUG, "unlink sock_name=%s",sock_name);
+				unlink(sock_name);
+				snprintf(sock_name,PATH_MAX,"%s-%s",base_name,"response");
+				qb_util_log(LOG_DEBUG, "unlink sock_name=%s",sock_name);
+				unlink(sock_name);
+			}
 		}
-                }
 		qb_ipcc_us_sock_close(c->setup.u.us.sock);
 		qb_ipcc_us_sock_close(c->request.u.us.sock);
 		qb_ipcc_us_sock_close(c->event.u.us.sock);

--- a/tests/check_ipc.c
+++ b/tests/check_ipc.c
@@ -1417,10 +1417,17 @@ END_TEST
 #ifdef HAVE_FAILURE_INJECTION
 START_TEST(test_ipcc_truncate_when_unlink_fails_shm)
 {
+	char sock_file[PATH_MAX];
 	qb_enter();
-	_fi_unlink_inject_failure = QB_TRUE;
 	ipc_type = QB_IPC_SHM;
 	set_ipc_name(__func__);
+
+	sprintf(sock_file, "%s/%s", SOCKETDIR, ipc_name);
+	/* If there's an old socket left from a previous run this test will fail
+	   unexpectedly, so try to remove it first */
+	unlink(sock_file);
+
+	_fi_unlink_inject_failure = QB_TRUE;
 	test_ipc_server_fail();
 	_fi_unlink_inject_failure = QB_FALSE;
 	qb_leave();


### PR DESCRIPTION
This patch enables system-wide selection of filesystem or abstract sockets when running on Linux. The default is still to use abstract sockets.

Filesystem sockets are needed when running libqb servers inside some containers where the abstract socket name space is shared, so abstract socket names would clash.