### PR TITLE
test: Fix random number generation in IPC tests

### DIFF
--- a/tests/check_ipc.c
+++ b/tests/check_ipc.c
@@ -1583,6 +1583,8 @@ main(void)
 	Suite *s;
 	int32_t do_shm_tests = QB_TRUE;
 
+	srandom(getpid());
+
 	set_ipc_name("ipc_test");
 #ifdef DISABLE_IPC_SHM
 	do_shm_tests = QB_FALSE;


### PR DESCRIPTION
The sockets are named using a random() suffix in at attempt to isolate
concurrent test. However random() always returns the same random number
by design. So I've added srandom(getpid()) to the start of the
IPC tests to make the randomisation actually work.

Signed-off-by: Christine Caulfield <ccaulfie@redhat.com>