### PR TITLE
Require c99 language support or newer

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -65,6 +65,10 @@ AC_PROG_AWK
 AC_PROG_CC
 AC_PROG_CPP
 AM_PROG_CC_C_O
+AC_PROG_CC_C99
+if test "x$ac_cv_prog_cc_c99" = "xno"; then
+	AC_MSG_ERROR(["C99 support is required"])
+fi
 AC_PROG_INSTALL
 AC_PROG_LN_S
 AC_PROG_MAKE_SET


### PR DESCRIPTION
Note also that gcc 5.4.0 and later default to the gnu11 version of the C11 standard.