### PR TITLE
build: follow-up on introducing custom m4 macros

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,11 @@ autom4te.cache/
 config.status
 configure
 .libs
-m4
+
+# ignore "libtoolized" m4 files, but keep our (custom-prefixed) ones
+/m4/*
+!/m4/ax_*.m4
+
 libtool
 .version
 .tarball-version

--- a/Makefile.am
+++ b/Makefile.am
@@ -47,9 +47,10 @@ doxygen:
 dist-clean-local:
 	rm -f autoconf automake autoheader
 
+# this will also get rid of "libtoolized" m4 files
 maintainer-clean-local:
-	rm -rf m4
 	rm -f .version .tarball-version
+	rm -f $(patsubst $(top_srcdir)/m4/ax_%,,$(wildcard $(top_srcdir)/m4/*.m4))
 
 clean-local:
 	rm -rf $(SPEC) $(DIST_ARCHIVES)

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 # Run this to generate all the initial makefiles, etc.
-mkdir -p m4
 autoreconf -i -v && echo Now run ./configure and make


### PR DESCRIPTION
Various "configure" commits by wferi recently introduced new
compat/custom m4 macro files in m4 directory, which itself was,
so far, assumed ephemeral (not strictly needed for reproducing
the build successfully, i.e., bits that can be completely purged
when cutting down the project files to the bone).  Apparently,
this assumption no longer holds so several places need to be
adapted.

Amonst others, m4 directory no longer needs to be reinsured in
autogen.sh, and special care must be taken with .gitignore
and maintainer-clean-local target of the main Makefile.

See also PR #240.