### PR TITLE
Adds additional warnings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -512,23 +512,29 @@ EXTRA_WARNINGS=""
 
 WARNLIST="
 	all
+	extra
+	unused
 	shadow
 	missing-prototypes
 	missing-declarations
+	suggest-attribute=noreturn
+	suggest-attribute=format
 	strict-prototypes
-	declaration-after-statement
 	pointer-arith
 	write-strings
 	cast-align
 	bad-function-cast
 	missing-format-attribute
+	float-equal
 	format=2
-	format-security
-	no-format-nonliteral
-	no-long-long
-	unsigned-char
-	gnu89-inline
-	no-strict-aliasing
+	format-signedness
+	shift-overflow=2
+	overlength-strings
+	redundent-decls
+	init-self
+	uninitialized
+	unknown-pragmas
+	no-unused-parameter
 	"
 
 for j in $WARNLIST; do

--- a/configure.ac
+++ b/configure.ac
@@ -535,6 +535,7 @@ WARNLIST="
 	uninitialized
 	unknown-pragmas
 	no-unused-parameter
+	no-format-nonliteral
 	"
 
 for j in $WARNLIST; do


### PR DESCRIPTION
This pull request reconfigures the warning settings in configure.ac.

The purpose is to leverage the compilers ability to analyze the code for potential pitfalls so that we can more easily address problems.

The specific changes will be documented in the diff.