### PR TITLE
configure: define AS_VAR_COPY

### DIFF
--- a/m4/ax_compat.m4
+++ b/m4/ax_compat.m4
@@ -1,0 +1,4 @@
+# For compatibility with autoconf < 2.63b
+m4_ifndef([AS_VAR_COPY],
+  [AC_DEFUN([AS_VAR_COPY],
+     [AS_LITERAL_IF([$1[]$2], [$1=$$2], [eval $1=\$$2])])])


### PR DESCRIPTION
See also https://github.com/ClusterLabs/libqb/pull/240#issuecomment-267611985.

The build error occurs with RHEL 6 series,
```
[root@rhel69-1 libqb]# cat /etc/redhat-release
Red Hat Enterprise Linux Server release 6.9 (Santiago)

[root@rhel69-1 libqb]# autoconf --version
autoconf (GNU Autoconf) 2.63

[root@rhel69-1 libqb]# git log --oneline -n 1
333fc80 log: use fdatasync instead of fsync where possible (#263)

[root@rhel69-1 libqb]# ./autogen.sh
(snip)
autoreconf: running: /usr/bin/autoconf
configure:18155: error: possibly undefined macro: AS_VAR_COPY
      If this token and others are legitimate, please use m4_pattern_allow.
      See the Autoconf documentation.
autoreconf: /usr/bin/autoconf failed with exit status: 1
```
so I wrote this patch.
```
[root@rhel69-1 libqb]# vi m4/ax_compat.m4
# For compatibility with autoconf < 2.63b
m4_ifndef([AS_VAR_COPY],
  [AC_DEFUN([AS_VAR_COPY],
     [AS_LITERAL_IF([$1[]$2], [$1=$$2], [eval $1=\$$2])])])

[root@rhel69-1 libqb]# ./autogen.sh
(snip)
autoreconf: running: /usr/bin/autoconf
autoreconf: running: /usr/bin/autoheader
autoreconf: running: automake --add-missing --copy --no-force
configure.ac:67: installing `build-aux/compile'
configure.ac:23: installing `build-aux/config.guess'
configure.ac:23: installing `build-aux/config.sub'
configure.ac:16: installing `build-aux/install-sh'
configure.ac:16: installing `build-aux/missing'
examples/Makefile.am: installing `build-aux/depcomp'
autoreconf: Leaving directory `.'
Now run ./configure and make

[root@rhel69-1 libqb]# ./configure
(snip)

libqb configuration:
  Version                  = 1.0.2.18-333f
  Prefix                   = /usr
  Executables              = ${exec_prefix}/sbin
  Man pages                = ${datarootdir}/man
  Doc dir                  = ${datarootdir}/doc/${PACKAGE_TARNAME}
  Libraries                = /usr/lib64
  Header files             = ${prefix}/include
  Arch-independent files   = ${datarootdir}
  State information        = /var
  System configuration     = /etc
  SOCKETDIR                = /var/run
  Features                 =  epoll gcc__sync attribute-section

libqb build info:
  Optimization             =
  Debug options            =
  Extra compiler warnings  =
  Env. defined CFLAG       = -g -O2
  Env. defined CPPFLAGS    =
  Env. defined LDFLAGS     =
  ANSI defined CPPFLAGS    =
  Coverage     CFLAGS      =
  Coverage     LDFLAGS     =
  Fatal War.   CFLAGS      =
  Final        CFLAGS      = -g -O2       -Wall -Wextra -Wunused -Wshadow -Wmissing-prototypes -Wmissing-declarations -Wstrict-prototypes -Wpointer-arith -Wwrite-strings -Wcast-align -Wbad-function-cast -Wmissing-format-attribute -Wfloat-equal -Wformat=2 -Woverlength-strings -Winit-self -Wuninitialized -Wunknown-pragmas -Wno-unused-parameter -Wno-format-nonliteral
  Final        CPPFLAGS    =
  Final        LDFLAGS     =
```