### PR TITLE
bconfigure: fix CLOCK_MONOTONIC check for cross-compilation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -183,7 +183,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
                  )
 
 AC_MSG_CHECKING(for a working clock_getres(CLOCK_MONOTONIC, &ts))
-AC_RUN_IFELSE([AC_LANG_PROGRAM(
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
 [[#include <time.h>]],
 [[struct timespec ts; if(clock_getres(CLOCK_MONOTONIC, &ts)) return -1;]])],
                     [


### PR DESCRIPTION
In cross-compilation, we can't run test programs, so configure just
bails out. Since there is no cache variable (e.g. ac_cv_blabla, we can't
even provide the correct result.

But in thise case, we don't really need to run to start with; we just
need to check if the toolchain headers know about CLOCK_MONOTONIC.

Signed-off-by: "Yann E. MORIN" <yann.morin.1998@free.fr>