### PR TITLE
maint: make -devel package dependency on the main package arch-qualified

### DIFF
--- a/libqb.spec.in
+++ b/libqb.spec.in
@@ -52,7 +52,8 @@ rm -rf $RPM_BUILD_ROOT/%{_datadir}/doc/libqb
 %package        devel
 Summary:        Development files for %{name}
 Group:          Development/Libraries
-Requires:       %{name} = %{version}-%{release} pkgconfig
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+Requires:       pkgconfig
 
 %description    devel
 The %{name}-devel package contains libraries and header files for


### PR DESCRIPTION
Beside the fact that libqb.pc is indeed arch-specific (see "libdir"
variable), it's also a matter of being disciplined per what distros
require:
https://fedoraproject.org/wiki/Packaging:Guidelines#Requiring_Base_Package

The syntactic provision at hand was introduced in rpm 4.6.0
(8+ years ago): http://rpm.org/user_doc/arch_dependencies.html

Signed-off-by: Jan Pokorný <jpokorny@redhat.com>