### PR TITLE
build: fix configure script neglecting, re-enable out-of-tree builds

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -710,7 +710,7 @@ if test "x${GCC}" = xyes; then
 			                      | grep __stop___verbose | cut -d" " -f 3)
 			 test "${verbose_start_addr}" = "${verbose_stop_addr}" \
 			   && gcc_has_attribute_section_visible=no \
-			   || { verbose_start_type=$(${READELF} -s backup \
+			   || { verbose_start_type=$(${READELF} -s "conftest${shrext_cmds}" \
 			                             | sed -n '/__start___verbose/{s/^\s*//p;q}' \
 			                             | tr -s ' ' \
 			                             | cut -d" " -f6)

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -101,7 +101,9 @@ endif
 endif
 
 qblog_script.ld: %.ld: %.ld.in
-	$(AM_V_GEN)$(CPP) -xc -I$(top_srcdir)/include -D_GNU_SOURCE -C -P $< \
+	$(AM_V_GEN)$(CPP) -C -D_GNU_SOURCE -P \
+	  -I$(top_srcdir)/include -I$(top_builddir)/include \
+	  -xc $< \
 	  | sed -n "/$$(sed -n '/^[^#]/{s/[*\/]/\\&/g;p;q;}' $<)/,$$ p" \
 	  > $@
 


### PR DESCRIPTION
For the former, a prototype and the final code got (hm, mysteriously)
intertwisted.  For the latter, I am clearly guilty of (rare, anyway)
testing of the out-of-tree builds only with libqb-already-system-wide
scenario, which is rather shortsighted.

Thanks Fabio and his ci.kronosnet.org project for spotting that.