### PR TITLE
Allow customisable log line length

### DIFF
--- a/include/qb/qblog.h
+++ b/include/qb/qblog.h
@@ -584,7 +584,7 @@ enum qb_log_conf {
 	QB_LOG_CONF_EXTENDED,
 	QB_LOG_CONF_IDENT,
 	QB_LOG_CONF_MAX_LINE_LEN,
-	QB_LOG_CONF_ELIPSIS,
+	QB_LOG_CONF_ELLIPSIS,
 };
 
 enum qb_log_filter_type {

--- a/include/qb/qblog.h
+++ b/include/qb/qblog.h
@@ -584,6 +584,7 @@ enum qb_log_conf {
 	QB_LOG_CONF_EXTENDED,
 	QB_LOG_CONF_IDENT,
 	QB_LOG_CONF_MAX_LINE_LEN,
+	QB_LOG_CONF_ELIPSIS,
 };
 
 enum qb_log_filter_type {

--- a/include/qb/qblog.h
+++ b/include/qb/qblog.h
@@ -265,6 +265,7 @@ extern "C" {
 #define LOG_TRACE    (LOG_DEBUG + 1)
 
 #define QB_LOG_MAX_LEN 512
+#define QB_LOG_ABSOLUTE_MAX_LEN 4096
 #define QB_LOG_STRERROR_MAX_LEN 128
 
 typedef const char *(*qb_log_tags_stringify_fn)(uint32_t tags);

--- a/include/qb/qblog.h
+++ b/include/qb/qblog.h
@@ -582,6 +582,7 @@ enum qb_log_conf {
 	QB_LOG_CONF_FILE_SYNC,
 	QB_LOG_CONF_EXTENDED,
 	QB_LOG_CONF_IDENT,
+	QB_LOG_CONF_MAX_LINE_LEN,
 };
 
 enum qb_log_filter_type {

--- a/lib/log.c
+++ b/lib/log.c
@@ -1222,7 +1222,12 @@ qb_log_ctl2(int32_t t, enum qb_log_conf c, qb_log_ctl2_arg_t arg_not4directuse)
 		conf[t].extended = arg_i32;
 		break;
 	case QB_LOG_CONF_MAX_LINE_LEN:
-		conf[t].max_line_length = arg_i32;
+		/* arbitrary limit, but you'd be insane to go further */
+		if (arg_i32 > QB_LOG_ABSOLUTE_MAX_LEN) {
+			rc = -EINVAL;
+		} else {
+			conf[t].max_line_length = arg_i32;
+		}
 		break;
 
 	default:

--- a/lib/log.c
+++ b/lib/log.c
@@ -1229,6 +1229,9 @@ qb_log_ctl2(int32_t t, enum qb_log_conf c, qb_log_ctl2_arg_t arg_not4directuse)
 			conf[t].max_line_length = arg_i32;
 		}
 		break;
+	case QB_LOG_CONF_ELIPSIS:
+		conf[t].elipsis = arg_i32;
+		break;
 
 	default:
 		rc = -EINVAL;

--- a/lib/log.c
+++ b/lib/log.c
@@ -1229,8 +1229,8 @@ qb_log_ctl2(int32_t t, enum qb_log_conf c, qb_log_ctl2_arg_t arg_not4directuse)
 			conf[t].max_line_length = arg_i32;
 		}
 		break;
-	case QB_LOG_CONF_ELIPSIS:
-		conf[t].elipsis = arg_i32;
+	case QB_LOG_CONF_ELLIPSIS:
+		conf[t].ellipsis = arg_i32;
 		break;
 
 	default:

--- a/lib/log.c
+++ b/lib/log.c
@@ -202,12 +202,8 @@ cs_format(char *str, size_t maxlen, struct qb_log_callsite *cs, va_list ap)
 	len = vsnprintf(str, maxlen, cs->format, ap_copy);
 	va_end(ap_copy);
 
-	/* Indicate overflow */
 	if (len > maxlen) {
 		len = maxlen;
-		str[maxlen-4] = '.';
-		str[maxlen-3] = '.';
-		str[maxlen-2] = '.';
 	}
 	if (str[len - 1] == '\n') {
 		str[len - 1] = '\0';

--- a/lib/log_blackbox.c
+++ b/lib/log_blackbox.c
@@ -114,7 +114,8 @@ _blackbox_vlogger(int32_t target,
 	if (msg_len >= max_size) {
 	    chunk = msg_len_pt + sizeof(uint32_t); /* Reset */
 
-	    msg_len = qb_vsnprintf_serialize(chunk, max_size,
+	    /* Leave this at QB_LOG_MAX_LEN so as not to overflow the blackbox */
+	    msg_len = qb_vsnprintf_serialize(chunk, QB_LOG_MAX_LEN,
 		"Log message too long to be stored in the blackbox.  "\
 		"Maximum is QB_LOG_MAX_LEN" , ap);
 	    actual_size += msg_len;

--- a/lib/log_blackbox.c
+++ b/lib/log_blackbox.c
@@ -70,7 +70,7 @@ _blackbox_vlogger(int32_t target,
 	fn_size = strlen(cs->function) + 1;
 
 	actual_size = 4 * sizeof(uint32_t) + sizeof(uint8_t) + fn_size + sizeof(time_t);
-	max_size = actual_size + QB_LOG_MAX_LEN;
+	max_size = actual_size + t->max_line_length;
 
 	chunk = qb_rb_chunk_alloc(t->instance, max_size);
 
@@ -110,11 +110,11 @@ _blackbox_vlogger(int32_t target,
 	chunk += sizeof(uint32_t);
 
 	/* log message */
-	msg_len = qb_vsnprintf_serialize(chunk, QB_LOG_MAX_LEN, cs->format, ap);
-	if (msg_len >= QB_LOG_MAX_LEN) {
+	msg_len = qb_vsnprintf_serialize(chunk, max_size, cs->format, ap);
+	if (msg_len >= max_size) {
 	    chunk = msg_len_pt + sizeof(uint32_t); /* Reset */
 
-	    msg_len = qb_vsnprintf_serialize(chunk, QB_LOG_MAX_LEN,
+	    msg_len = qb_vsnprintf_serialize(chunk, max_size,
 		"Log message too long to be stored in the blackbox.  "\
 		"Maximum is QB_LOG_MAX_LEN" , ap);
 	    actual_size += msg_len;

--- a/lib/log_file.c
+++ b/lib/log_file.c
@@ -25,12 +25,19 @@ static void
 _file_logger(int32_t t,
 	     struct qb_log_callsite *cs, time_t timestamp, const char *msg)
 {
-	char output_buffer[QB_LOG_MAX_LEN];
+	char buffer[QB_LOG_MAX_LEN];
+	char *output_buffer = buffer;
 	struct qb_log_target *target = qb_log_target_get(t);
 	FILE *f = qb_log_target_user_data_get(t);
 
 	if (f == NULL) {
 		return;
+	}
+	if (target->max_line_length > QB_LOG_MAX_LEN) {
+		output_buffer = malloc(target->max_line_length);
+		if (!output_buffer) {
+			return;
+		}
 	}
 	output_buffer[0] = '\0';
 
@@ -41,6 +48,9 @@ _file_logger(int32_t t,
 	fflush(f);
 	if (target->file_sync) {
 		QB_FILE_SYNC(fileno(f));
+	}
+	if (target->max_line_length > QB_LOG_MAX_LEN) {
+		free(output_buffer);
 	}
 }
 

--- a/lib/log_format.c
+++ b/lib/log_format.c
@@ -435,6 +435,13 @@ qb_log_target_format(int32_t target,
 	} else {
 		output_buffer[output_buffer_idx] = '\0';
 	}
+
+	/* Indicate truncation */
+	if (output_buffer_idx >= t->max_line_length-1) {
+		output_buffer[output_buffer_idx-3] = '.';
+		output_buffer[output_buffer_idx-2] = '.';
+		output_buffer[output_buffer_idx-1] = '.';
+	}
 }
 
 

--- a/lib/log_format.c
+++ b/lib/log_format.c
@@ -437,7 +437,7 @@ qb_log_target_format(int32_t target,
 	}
 
 	/* Indicate truncation */
-	if (t->elipsis && output_buffer_idx >= t->max_line_length-1) {
+	if (t->ellipsis && output_buffer_idx >= t->max_line_length-1) {
 		output_buffer[output_buffer_idx-3] = '.';
 		output_buffer[output_buffer_idx-2] = '.';
 		output_buffer[output_buffer_idx-1] = '.';

--- a/lib/log_format.c
+++ b/lib/log_format.c
@@ -437,7 +437,7 @@ qb_log_target_format(int32_t target,
 	}
 
 	/* Indicate truncation */
-	if (output_buffer_idx >= t->max_line_length-1) {
+	if (t->elipsis && output_buffer_idx >= t->max_line_length-1) {
 		output_buffer[output_buffer_idx-3] = '.';
 		output_buffer[output_buffer_idx-2] = '.';
 		output_buffer[output_buffer_idx-1] = '.';

--- a/lib/log_format.c
+++ b/lib/log_format.c
@@ -290,12 +290,12 @@ qb_log_target_format_static(int32_t target, const char * format,
 			}
 			len = _strcpy_cutoff(output_buffer + output_buffer_idx,
 					     p, cutoff, ralign,
-					     (QB_LOG_MAX_LEN -
+					     (t->max_line_length -
 					      output_buffer_idx));
 			output_buffer_idx += len;
 			format_buffer_idx += 1;
 		}
-		if (output_buffer_idx >= QB_LOG_MAX_LEN - 1) {
+		if (output_buffer_idx >= t->max_line_length - 1) {
 			break;
 		}
 	}
@@ -419,12 +419,12 @@ qb_log_target_format(int32_t target,
 			}
 			len = _strcpy_cutoff(output_buffer + output_buffer_idx,
 					     p, cutoff, ralign,
-					     (QB_LOG_MAX_LEN -
+					     (t->max_line_length -
 					      output_buffer_idx));
 			output_buffer_idx += len;
 			format_buffer_idx += 1;
 		}
-		if (output_buffer_idx >= QB_LOG_MAX_LEN - 1) {
+		if (output_buffer_idx >= t->max_line_length - 1) {
 			break;
 		}
 	}

--- a/lib/log_int.h
+++ b/lib/log_int.h
@@ -40,6 +40,7 @@ struct qb_log_target {
 	int32_t debug;
 	int32_t extended;
 	size_t size;
+	size_t max_line_length;
 	char *format;
 	int32_t threaded;
 	void *instance;

--- a/lib/log_int.h
+++ b/lib/log_int.h
@@ -41,7 +41,7 @@ struct qb_log_target {
 	int32_t extended;
 	size_t size;
 	size_t max_line_length;
-	int32_t elipsis;
+	int32_t ellipsis;
 	char *format;
 	int32_t threaded;
 	void *instance;

--- a/lib/log_int.h
+++ b/lib/log_int.h
@@ -41,6 +41,7 @@ struct qb_log_target {
 	int32_t extended;
 	size_t size;
 	size_t max_line_length;
+	int32_t elipsis;
 	char *format;
 	int32_t threaded;
 	void *instance;

--- a/tests/check_log.c
+++ b/tests/check_log.c
@@ -306,7 +306,7 @@ START_TEST(test_line_length)
 	rc = qb_log_filter_ctl(t, QB_LOG_FILTER_ADD,
 			  QB_LOG_FILTER_FORMAT, "*", LOG_WARNING);
 	ck_assert_int_eq(rc, 0);
-	qb_log_format_set(t, "%b");
+	qb_log_format_set(t, "[%p] %b");
 	rc = qb_log_ctl(t, QB_LOG_CONF_ENABLED, QB_TRUE);
 	ck_assert_int_eq(rc, 0);
 	rc = qb_log_ctl(t, QB_LOG_CONF_MAX_LINE_LEN, 32);
@@ -317,7 +317,7 @@ START_TEST(test_line_length)
 	test_priority = 0;
 	num_msgs = 0;
 
-	qb_log(LOG_ERR, "This is a short message");
+	qb_log(LOG_ERR, "Short message");
 	qb_log(LOG_ERR, "This is a longer message 123456789012345678901234567890");
 	qb_log(LOG_ERR, "Long message with parameters %d %s", 1234, "Oh yes it is");
 

--- a/tests/check_log.c
+++ b/tests/check_log.c
@@ -311,6 +311,8 @@ START_TEST(test_line_length)
 	ck_assert_int_eq(rc, 0);
 	rc = qb_log_ctl(t, QB_LOG_CONF_MAX_LINE_LEN, 32);
 	ck_assert_int_eq(rc, 0);
+	rc = qb_log_ctl(t, QB_LOG_CONF_ELIPSIS, QB_TRUE);
+	ck_assert_int_eq(rc, 0);
 
 	/* captures last log */
 	memset(test_buf, 0, sizeof(test_buf));
@@ -325,6 +327,12 @@ START_TEST(test_line_length)
 	ck_assert_int_eq(last_length, 31);
 
 	ck_assert_str_eq(test_buf+28, "...");
+
+	rc = qb_log_ctl(t, QB_LOG_CONF_ELIPSIS, QB_FALSE);
+	ck_assert_int_eq(rc, 0);
+
+	qb_log(LOG_ERR, "Long message with parameters %d %s", 1234, "Oh yes it is");
+	ck_assert_str_ne(test_buf+28, "...");
 
 	/* Long lines */
 	num_msgs = 0;

--- a/tests/check_log.c
+++ b/tests/check_log.c
@@ -187,9 +187,10 @@ START_TEST(test_log_stupid_inputs)
 }
 END_TEST
 
-static char test_buf[QB_LOG_MAX_LEN];
+static char test_buf[4097];
 static uint8_t test_priority;
 static int32_t num_msgs;
+static size_t last_length;
 
 /*
  * to test that we get what we expect.
@@ -204,6 +205,19 @@ _test_logger(int32_t t,
 	test_priority = cs->priority;
 
 	num_msgs++;
+}
+
+static void
+_test_length_logger(int32_t t,
+	     struct qb_log_callsite *cs,
+	     time_t timestamp, const char *msg)
+{
+	strcpy(test_buf, msg);
+	qb_log_target_format(t, cs, timestamp, msg, test_buf);
+	test_priority = cs->priority;
+
+	num_msgs++;
+	last_length = strlen(msg);
 }
 
 static void log_also(void)
@@ -275,6 +289,55 @@ START_TEST(test_log_filter_fn)
 				    __LINE__, 0, "qb_log_filter_fn_set bad");
 
 	ck_assert_int_eq(num_msgs, 3);
+}
+END_TEST
+
+START_TEST(test_line_length)
+{
+	int32_t t;
+	int32_t rc;
+	int i;
+	char bigbuf[4097];
+
+	qb_log_init("test", LOG_USER, LOG_EMERG);
+	qb_log_ctl(QB_LOG_SYSLOG, QB_LOG_CONF_ENABLED, QB_FALSE);
+
+	t = qb_log_custom_open(_test_length_logger, NULL, NULL, NULL);
+	rc = qb_log_filter_ctl(t, QB_LOG_FILTER_ADD,
+			  QB_LOG_FILTER_FORMAT, "*", LOG_WARNING);
+	ck_assert_int_eq(rc, 0);
+	qb_log_format_set(t, "%b");
+	rc = qb_log_ctl(t, QB_LOG_CONF_ENABLED, QB_TRUE);
+	ck_assert_int_eq(rc, 0);
+	rc = qb_log_ctl(t, QB_LOG_CONF_MAX_LINE_LEN, 32);
+	ck_assert_int_eq(rc, 0);
+
+	/* captures last log */
+	memset(test_buf, 0, sizeof(test_buf));
+	test_priority = 0;
+	num_msgs = 0;
+
+	qb_log(LOG_ERR, "This is a short message");
+	qb_log(LOG_ERR, "This is a longer message 123456789012345678901234567890");
+	qb_log(LOG_ERR, "Long message with parameters %d %s", 1234, "Oh yes it is");
+
+	ck_assert_int_eq(num_msgs, 3);
+	ck_assert_int_eq(last_length, 31);
+
+	ck_assert_str_eq(test_buf+28, "...");
+
+	/* Long lines */
+	num_msgs = 0;
+	rc = qb_log_ctl(t, QB_LOG_CONF_MAX_LINE_LEN, 4096);
+	ck_assert_int_eq(rc, 0);
+
+	for (i=0; i<4096; i++) {
+		bigbuf[i] = '0'+(i%10);
+	}
+	bigbuf[4096] = '\0';
+	qb_log(LOG_ERR, "%s", bigbuf);
+	ck_assert_int_eq(num_msgs, 1);
+	ck_assert_int_eq(last_length, 4095);
 }
 END_TEST
 
@@ -889,6 +952,7 @@ log_suite(void)
 	add_tcase(s, tc, test_log_long_msg);
 	add_tcase(s, tc, test_log_filter_fn);
 	add_tcase(s, tc, test_threaded_logging);
+	add_tcase(s, tc, test_line_length);
 #ifdef HAVE_PTHREAD_SETSCHEDPARAM
 	add_tcase(s, tc, test_threaded_logging_bad_sched_params);
 #endif

--- a/tests/check_log.c
+++ b/tests/check_log.c
@@ -311,7 +311,7 @@ START_TEST(test_line_length)
 	ck_assert_int_eq(rc, 0);
 	rc = qb_log_ctl(t, QB_LOG_CONF_MAX_LINE_LEN, 32);
 	ck_assert_int_eq(rc, 0);
-	rc = qb_log_ctl(t, QB_LOG_CONF_ELIPSIS, QB_TRUE);
+	rc = qb_log_ctl(t, QB_LOG_CONF_ELLIPSIS, QB_TRUE);
 	ck_assert_int_eq(rc, 0);
 
 	/* captures last log */
@@ -328,7 +328,7 @@ START_TEST(test_line_length)
 
 	ck_assert_str_eq(test_buf+28, "...");
 
-	rc = qb_log_ctl(t, QB_LOG_CONF_ELIPSIS, QB_FALSE);
+	rc = qb_log_ctl(t, QB_LOG_CONF_ELLIPSIS, QB_FALSE);
 	ck_assert_int_eq(rc, 0);
 
 	qb_log(LOG_ERR, "Long message with parameters %d %s", 1234, "Oh yes it is");

--- a/tests/functional/log_test_client.err
+++ b/tests/functional/log_test_client.err
@@ -1,2 +1,2 @@
 [MAIN |debug] ../log_client.c:69:hello
-[libqb|error] log_blackbox.c:196:qb_log_blackbox_print_from_file:
+[libqb|error] log_blackbox.c:197:qb_log_blackbox_print_from_file:

--- a/tests/functional/log_test_interlib_client.err
+++ b/tests/functional/log_test_interlib_client.err
@@ -1,4 +1,4 @@
 [MAIN |info] ../log_interlib_client.c:61:BEFORE
 [MAIN |info] ../log_interlib.c:47:aloha
-[libqb|error] log_blackbox.c:196:qb_log_blackbox_print_from_file:
+[libqb|error] log_blackbox.c:197:qb_log_blackbox_print_from_file:
 [MAIN |info] ../log_interlib_client.c:65:AFTER


### PR DESCRIPTION
Allow the logging line length to be changed. Any reasonable length is allowable, the default is 512 as before. Anything more than 512 incurs several mallocs.

Log lines that exceed the length will have ... as the last 3 characters.