### PR TITLE
tests: Improve test isolation

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -103,16 +103,16 @@ bench_log_CPPFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include
 bench_log_LDADD = $(top_builddir)/lib/libqb.la
 
 if HAVE_CHECK
-EXTRA_DIST += resources.test
+EXTRA_DIST += start.test resources.test
 EXTRA_DIST += blackbox-segfault.sh
 
-TESTS = array.test map.test rb.test log.test blackbox-segfault.sh loop.test ipc.test resources.test
+TESTS = start.test array.test map.test rb.test log.test blackbox-segfault.sh loop.test ipc.test resources.test
 
 resources.log: rb.log log.log ipc.log
 
 check_LTLIBRARIES =
 check_PROGRAMS = array.test map.test rb.test log.test loop.test ipc.test util.test crash_test_dummy file_change_bytes
-dist_check_SCRIPTS = resources.test blackbox-segfault.sh
+dist_check_SCRIPTS = start.test resources.test blackbox-segfault.sh
 
 if HAVE_SLOW_TESTS
 TESTS += util.test

--- a/tests/resources.test
+++ b/tests/resources.test
@@ -1,15 +1,16 @@
 #!/bin/sh
 RETURN=0
 
+IPC_NAME=`cat ipc-test-name`
 for d in /dev/shm /var/run; do
-	leftovers=$(find $d -name qb-test* -size +0c 2>/dev/null | wc -l)
+	leftovers=$(find $d -name qb-test*${IPC_NAME}* -size +0c 2>/dev/null | wc -l)
 	if [ "${leftovers}" -gt 0 ]; then
 		echo
 		echo "Error: shared memory segments not closed/unlinked"
 		echo
 		RETURN=1
 	fi
-	leftovers="$(find $d -name qb-test* -size 0c 2>/dev/null)"
+	leftovers="$(find $d -name qb-test*${IPC_NAME}* -size 0c 2>/dev/null)"
 	if [ "$(printf '%s\n' "${leftovers}" | wc -l)" -eq 6 ]; then
 		echo
 		echo "There were some empty leftovers (expected), removing them"


### PR DESCRIPTION
Make all the IPC tests run with a common date/pid stamp name, so that
the final resource.test only fails if it finds one of OUR files left
lying around and not those from another test.

Signed-off-by: Christine Caulfield <ccaulfie@redhat.com>