### PR TITLE
Fix distcheck

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,6 +37,9 @@ MAINTAINERCLEANFILES	= Makefile.in aclocal.m4 configure depcomp \
 
 ACLOCAL_AMFLAGS		= -I m4
 
+# For test suite
+export SOCKETDIR
+
 dist_doc_DATA		= COPYING INSTALL README.markdown
 
 SUBDIRS			= include lib docs tools tests examples

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -137,6 +137,8 @@ install-exec-hook: qblog_script.ld
 	  sed -i -- "s/libqb.so.<digit>/$${so_ver}/" \
 	    "$(DESTDIR)$(libdir)/libqb.so-t" "$(DESTDIR)$(pkgconfigexecdir)/libqb.pc"
 	mv -f "$(DESTDIR)$(libdir)/libqb.so-t" "$(DESTDIR)$(libdir)/libqb.so"
+	rm -f "$(DESTDIR)$(pkgconfigexecdir)/libqb.pc--"
+	rm -f "$(DESTDIR)$(libdir)/libqb.so-t--"
 endif
 
 if HAVE_SPLINT

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -80,8 +80,9 @@ check: check-headers
 .PHONY: check-headers
 check-headers: $(auto_c_files:.c=.o)
 
-distclean-compile:
+distclean-local:
 	rm -rf auto_*.c
+	rm -rf .deps
 
 if HAVE_DICT_WORDS
 if HAVE_SLOW_TESTS

--- a/tests/functional/GNUmakefile
+++ b/tests/functional/GNUmakefile
@@ -10,7 +10,7 @@ distclean maintainer-clean:
 	# includes, which are swiped when processing one subdir and then
 	# missing, as a hard error, for the other)
 	@$(MAKE) -C log_external $@
-	@mkdir .deps
+	@mkdir -p .deps
 	@touch .deps/log_client.Po .deps/log_interlib.Plo .deps/log_interlib_client.Po
 	@$(MAKE) -C log_internal $@
 	@$(MAKE) -f Makefile $@ SUBDIRS=

--- a/tests/resources.test
+++ b/tests/resources.test
@@ -2,7 +2,7 @@
 RETURN=0
 
 IPC_NAME=`cat ipc-test-name 2>/dev/null`
-for d in /dev/shm /var/run; do
+for d in /dev/shm /var/run $SOCKETDIR; do
 	leftovers=$(find $d -name qb-test*${IPC_NAME}* -size +0c 2>/dev/null | wc -l)
 	if [ "${leftovers}" -gt 0 ]; then
 		echo
@@ -30,4 +30,7 @@ if [ $? -eq 0 ]; then
 	RETURN=1
 fi
 
+# Keep it tidy - distcheck checks we have not left a mess
+rm -f ipc-test-name
+rm -f crash_test_dummy.core
 exit $RETURN

--- a/tests/start.test
+++ b/tests/start.test
@@ -8,3 +8,4 @@
 #
 NAME="$$-`date +%N`"
 echo -n "$NAME" > ipc-test-name
+mkdir -p $SOCKETDIR


### PR DESCRIPTION
Miscellaneous fixes and cleanups to get 'make distcheck' to work on most platforms.

There's a thing in here to speed up the FreeBSD IPC stress tests. I know it means that the BSD test is no longer really a stress test, but it can take over an hour to run with 70000 iterations and that;s just getting in everyone's way.