### PR TITLE
ipc_shm: Don't truncate SHM files of an active server

### DIFF
--- a/include/qb/qbipcs.h
+++ b/include/qb/qbipcs.h
@@ -142,6 +142,10 @@ typedef void (*qb_ipcs_connection_created_fn) (qb_ipcs_connection_t *c);
  * successfully created.
  * @note if you return anything but 0 this function will be
  * repeatedly called (until 0 is returned).
+ *
+ * With SHM connections libqb will briefly trap SIGBUS during the
+ * disconnect process to guard against server crashes if the mapped
+ * file is truncated. The signal will be restored afterwards.
  */
 typedef int32_t (*qb_ipcs_connection_closed_fn) (qb_ipcs_connection_t *c);
 

--- a/lib/ipc_int.h
+++ b/lib/ipc_int.h
@@ -92,6 +92,7 @@ struct qb_ipcc_connection {
 	char name[NAME_MAX];
 	int32_t needs_sock_for_poll;
 	gid_t egid;
+	pid_t server_pid;
 	struct qb_ipc_one_way setup;
 	struct qb_ipc_one_way request;
 	struct qb_ipc_one_way response;

--- a/lib/ipc_setup.c
+++ b/lib/ipc_setup.c
@@ -494,6 +494,7 @@ qb_ipcc_us_setup_connect(struct qb_ipcc_connection *c,
 
 	qb_ipc_auth_creds(data);
 	c->egid = data->ugp.gid;
+	c->server_pid = data->ugp.pid;
 
 	destroy_ipc_auth_data(data);
 	return r->hdr.error;


### PR DESCRIPTION
I've put in an extra check so that clients don't truncate the
SHM file if the server still exists. Sadly on FreeBSD we can't
get the server PID for the client (unless someone has a patch handy!)
so we still do the truncate when disconnected. As a backstop (and also
to cover the BSD issue) I've added a SIGBUS trap to the server shutdown
so that it doesn't cause a server crash.

Signed-off-by: Christine Caulfield <ccaulfie@redhat.com>