### PR TITLE
log: Use RTLD_NOLOADwhen checking symbols

### DIFF
--- a/lib/log.c
+++ b/lib/log.c
@@ -831,7 +831,7 @@ _log_so_walk_dlnames(void)
 	qb_list_for_each_safe(iter, next, &dlnames) {
 		dlname = qb_list_entry(iter, struct dlname, list);
 
-		handle = dlopen(dlname->dln_name, RTLD_LAZY);
+		handle = dlopen(dlname->dln_name, RTLD_LAZY|RTLD_NOLOAD);
 		error = dlerror();
 		if (!handle || error) {
 			qb_log(LOG_ERR, "%s", error);


### PR DESCRIPTION
On FreeBSD 11 call dlopen on a shared library causes the constructors
to run again. As we're just getting symbols we don't need this to
happen.

Actually we don't WANT it to happen because it can cause qb_log_init to
be called twice (recursively) and the dlnames list gets corrupted. This
causes corosync (at least) to crash at startup.

Signed-off-by: Christine Caulfield <ccaulfie@redhat.com>