### PR TITLE
blackbox-segfault test - remove residual core files

### DIFF
--- a/tests/blackbox-segfault.sh
+++ b/tests/blackbox-segfault.sh
@@ -3,6 +3,7 @@
 # create a normal blackbox
 rm -f crash-test-dummy.fdata
 ./crash_test_dummy
+rm -f core*
 
 . ./test.conf
 


### PR DESCRIPTION
travis test failures on disttest showed corefiles left over. May as well remove them in the blackbox-segfault test.