### PR TITLE
Use git archive stored version tag

### DIFF
--- a/.gitarchivever
+++ b/.gitarchivever
@@ -1,0 +1,1 @@
+ref names:$Format:%d$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.gitarchivever export-subst

--- a/Makefile.am
+++ b/Makefile.am
@@ -71,7 +71,7 @@ $(SPEC): $(SPEC).in
 		alphatag="" && \
 		dirty="" && \
 		numcomm="0"; \
-	else \
+	elif [ "`git log -1 --pretty=format:x . 2>&1`" = "x" ]; then \
 		ver="$(shell git describe --abbrev=4 --match='v*' --tags HEAD 2>/dev/null)" && \
 		gitver=`echo $$ver | sed \
 			-e 's|^\(v[0-9][0-9]*\.[0-9][0-9]*\)\([^.].*\)\?$$|\1.0\2|'` && \
@@ -81,6 +81,13 @@ $(SPEC): $(SPEC).in
 		numcomm=`git rev-list $$vtag..HEAD | wc -l` && \
 		git update-index --refresh > /dev/null 2>&1 || true && \
 		dirty=`git diff-index --name-only HEAD 2>/dev/null`; \
+	else \
+		gitver="$(shell build-aux/git-version-gen .tarball-version .gitarchivever \
+		    's|^\(v[0-9][0-9]*\.[0-9][0-9]*\)\([^.].*\)\?$$|\1.0\2|')" && \
+		rpmver=$$gitver && \
+		alphatag="" && \
+		dirty="" && \
+		numcomm="0"; \
 	fi && \
 	if [ -n "$$dirty" ]; then dirty="dirty"; else dirty=""; fi && \
 	if [ "$$numcomm" = "0" ]; then \

--- a/build-aux/git-version-gen
+++ b/build-aux/git-version-gen
@@ -223,6 +223,14 @@ else
     v=$fallback
 fi
 
+if test "x$fallback" = x -a "$v" = "UNKNOWN"
+then
+  echo "$0: ERROR: Can't find valid version. Please use valid git repository," \
+    "released tarball or version tagged archive" 1>&2
+
+  exit 1
+fi
+
 v=`echo "$v" |sed "s/^$prefix//"`
 
 # Test whether to append the "-dirty" suffix only if the version

--- a/build-aux/git-version-gen
+++ b/build-aux/git-version-gen
@@ -1,7 +1,8 @@
 #!/bin/sh
 # Print a version string.
-scriptversion=2016-01-11.22; # UTC
+scriptversion=2018-09-03.20; # UTC
 
+# Copyright (C) 2018 Red Hat, Inc.
 # Copyright (C) 2007-2016 Free Software Foundation, Inc.
 #
 # This program is free software: you can redistribute it and/or modify
@@ -49,6 +50,17 @@ scriptversion=2016-01-11.22; # UTC
 # .tarball-version is never generated in a VC'd directory, so needn't
 # be listed there.
 #
+# In order to use git archive versions another two files has to be presented:
+#
+# .gitarchive-version - present in checked-out repository and git
+#   archive tarball, but not in the distribution tarball. Used as a last
+#   option for version. File must contain special string $Format:%d$,
+#   which is substitued by git on archive operation.
+#
+# .gitattributes - present in checked-out repository and git archive
+#   tarball, but not in the distribution tarball. Must set export-subst
+#   attribute for .gitarchive-version file.
+#
 # Use the following line in your configure.ac, so that $(VERSION) will
 # automatically be up-to-date each time configure is run (and note that
 # since configure.ac no longer includes a version string, Makefile rules
@@ -80,7 +92,7 @@ under the terms of the GNU General Public License.
 For more information about these matters, see the files named COPYING."
 
 usage="\
-Usage: $me [OPTION]... \$srcdir/.tarball-version [TAG-NORMALIZATION-SED-SCRIPT]
+Usage: $me [OPTION]... \$srcdir/.tarball-version [\$srcdir/.gitarchive-version] [TAG-NORMALIZATION-SED-SCRIPT]
 Print a version string.
 
 Options:
@@ -110,6 +122,8 @@ while test $# -gt 0; do
     *)
       if test "x$tarball_version_file" = x; then
         tarball_version_file="$1"
+      elif test "x$gitarchive_version_file" = x; then
+        gitarchive_version_file="$1"
       elif test "x$tag_sed_script" = x; then
         tag_sed_script="$1"
       else
@@ -189,7 +203,22 @@ then
     v=`echo "$v" | sed 's/-/./;s/\(.*\)-g/\1-/'`;
     v_from_git=1
 elif test "x$fallback" = x || git --version >/dev/null 2>&1; then
-    v=UNKNOWN
+    if test -f $gitarchive_version_file
+    then
+        v=`sed "s/^.*tag: \($prefix[0-9)][^,)]*\).*\$/\1/" $gitarchive_version_file \
+            | sed "$tag_sed_script"` || exit 1
+        case $v in
+            *$nl*) v= ;; # reject multi-line output
+            $prefix[0-9]*) ;;
+            *) v= ;;
+        esac
+
+        test -z "$v" \
+            && echo "$0: WARNING: $gitarchive_version_file doesn't contain valid version tag" 1>&2 \
+            && v=UNKNOWN
+    else
+        v=UNKNOWN
+    fi
 else
     v=$fallback
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@ AC_PREREQ([2.61])
 
 dnl inject zero as a "patch" component of the version if missing in tag
 AC_INIT([libqb],
-	m4_esyscmd([build-aux/git-version-gen .tarball-version \
+	m4_esyscmd([build-aux/git-version-gen .tarball-version .gitarchivever \
 		    's|^\(v[0-9][0-9]*\.[0-9][0-9]*\)\([^.].*\)\?$|\1.0\2|']),
 	[developers@clusterlabs.org])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION
Enhanced version of https://github.com/corosync/corosync/commit/0b0f32c56fb391dc6b093d7cb4aff4215eaa7f44 which should work with sed tag script. I'm not entirely happy with 3rd patch, because with little hacking it should be possible to reduce 3 cases into one call of git-version-gen, but this may be another PR.