### PR TITLE
build: allow for being consumed in a (discouraged) form of snapshots

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/configure.ac export-subst

--- a/.gitignore
+++ b/.gitignore
@@ -16,24 +16,32 @@ autom4te.cache/
 config.status
 configure
 conftest.*
-.libs
 
-# since we use subdir-objects as automake option
-.dirstamp
+
+# dotfiles
+
+.*
+# - subsumed:
+#   .dirstamp (since we use subdir-objects as automake option)
+#   .libs
+#   .{,snapshot-,tarball-}version
+# - sans:
+!.git*
+!/.tito
+!/.travis.yml
+
 
 # ignore "libtoolized" m4 files, but keep our (custom-prefixed) ones
 /m4/*
 !/m4/ax_*.m4
 
 # build-aux/release.mk related litter
-/.tarball-version
 /tag-*
 
 /lib/qblog_script.ld
 # already captured with wildcard: /lib/qblog_script.la
 
 libtool
-.version
 libqb.spec
 libqb-*
 cov

--- a/Makefile.am
+++ b/Makefile.am
@@ -48,7 +48,7 @@ doxygen:
 	$(MAKE) -C docs doxygen
 
 dist-clean-local:
-	rm -f autoconf automake autoheader
+	rm -f .snapshot-version autoconf automake autoheader
 
 # this will also get rid of "libtoolized" m4 files
 maintainer-clean-local:
@@ -63,26 +63,25 @@ clean-local:
 $(SPEC): $(SPEC).in
 	@rm -f $@-t $@
 	@date="$(shell LC_ALL=C date "+%a %b %d %Y")" && \
-	if [ -f .tarball-version ]; then \
-		ver="$(shell cat .tarball-version)" && \
-		gitver=`echo $$ver | sed \
-			-e 's|^\(v[0-9][0-9]*\.[0-9][0-9]*\)\([^.].*\)\?$$|\1.0\2|'` && \
-		rpmver=$$gitver && \
+	if [ -s .tarball-version ] || [ -n "$$(echo '${VERSION}' | grep -v UNKNOWN)" ]; then \
+		ver="$$({ cat .tarball-version 2>/dev/null; echo '${VERSION}'; } | head -n1)" && \
+		gitver=$$(echo $$ver | sed \
+		          -e 's|^\(v[0-9][0-9]*\.[0-9][0-9]*\)\([^.].*\)\?$$|\1.0\2|') && \
+		rpmver=$$(echo $$gitver | sed 's/-.*//') && \
 		alphatag="" && \
-		dirty="" && \
+		dirty=$$(echo $$gitver | sed -n 's/[^-][^-]*-//p') && \
 		numcomm="0"; \
 	else \
 		ver="$(shell git describe --abbrev=4 --match='v*' --tags HEAD 2>/dev/null)" && \
-		gitver=`echo $$ver | sed \
-			-e 's|^\(v[0-9][0-9]*\.[0-9][0-9]*\)\([^.].*\)\?$$|\1.0\2|'` && \
-		rpmver=`echo $$gitver | sed -e "s/^v//" -e "s/-.*//g"` && \
-		alphatag=`echo $$gitver | sed -e "s/.*-//" -e "s/^g//"` && \
-		vtag=`echo $$ver | sed -e "s/-.*//g"` && \
-		numcomm=`git rev-list $$vtag..HEAD | wc -l` && \
+		gitver=$$(echo $$ver | sed \
+		          -e 's|^\(v[0-9][0-9]*\.[0-9][0-9]*\)\([^.].*\)\?$$|\1.0\2|') && \
+		rpmver=$$(echo $$gitver | sed -e "s/^v//" -e "s/-.*//g") && \
+		alphatag=$$(echo $$gitver | sed -e "s/.*-//" -e "s/^g//") && \
+		vtag=$$(echo $$ver | sed -e "s/-.*//g") && \
+		numcomm=$$(git rev-list $$vtag..HEAD | wc -l) && \
 		git update-index --refresh > /dev/null 2>&1 || true && \
-		dirty=`git diff-index --name-only HEAD 2>/dev/null`; \
+		dirty=$$(git diff-index --name-only HEAD 2>/dev/null | sed 's/..*/dirty/'); \
 	fi && \
-	if [ -n "$$dirty" ]; then dirty="dirty"; else dirty=""; fi && \
 	if [ "$$numcomm" = "0" ]; then \
 		sed \
 			-e "s#@version@#$$rpmver#g" \
@@ -128,8 +127,14 @@ BUILT_SOURCES	= .version
 .version:
 	echo $(VERSION) > $@-t && mv $@-t $@
 
+# untaint configure.ac when modified upon obtaining the "yanked" snapshot form
 dist-hook: gen-ChangeLog
-	echo $(VERSION) > $(distdir)/.tarball-version
+	echo $(VERSION) | tee $(distdir)/.tarball-version | grep -Eqv '\-yank' \
+	  || sed "s/\(.*git-version-gen[^']*[']\)[^']*/\1\$$Format:%h??%D\$$/" \
+	     $(distdir)/configure.ac > $(builddir)/configure.ac-t
+	touch -r $(distdir)/configure.ac $(builddir)/configure.ac-t
+	chmod u+w $(distdir)/configure.ac
+	mv $(builddir)/configure.ac-t $(distdir)/configure.ac
 
 gen_start_date = 2000-01-01
 .PHONY: gen-ChangeLog

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,3 +1,22 @@
 #!/bin/sh
 # Run this to generate all the initial makefiles, etc.
-autoreconf -i -v && echo Now run ./configure and make
+
+version_files=".snapshot-version .tarball-version .version"
+work_tree=0; test -n "$(cat $version_files 2>/dev/null|head -n1)" || work_tree=1
+autoreconf_opts=${autoreconf_opts=-i -v}; test $# -eq 0 || autoreconf_opts=$*
+# -f to always adapt to actual project's version dynamically @ dev's checkout
+test $work_tree -eq 0 || autoreconf_opts="$autoreconf_opts -f"
+
+autoreconf $autoreconf_opts || exit $?
+if grep -Eq '\-yank' $version_files 2>/dev/null; then
+    echo ': CONSUME SNAPSHOTS ONLY AT YOUR RISK (genuine releases recommended!)'
+    printf ': snapshot version: '
+elif test $work_tree -eq 0; then
+    echo ': About to consume a source distribution (genuine release advised)...'
+    printf ': tracked version: '
+else
+    echo ': About to consume a checked out tree (dedicated for maintenance!)...'
+fi
+cat $version_files 2>/dev/null | head -n1; rm -f .snapshot-version
+
+echo ': Now run ./configure && make'

--- a/configure.ac
+++ b/configure.ac
@@ -3,10 +3,16 @@
 
 AC_PREREQ([2.61])
 
-dnl inject zero as a "patch" component of the version if missing in tag
+dnl inject zero as a "patch" component of the version if missing in tag;
+dnl care to bump "X.Y.Z-yank" template below upon each release very desirable
 AC_INIT([libqb],
-	m4_esyscmd([build-aux/git-version-gen .tarball-version \
-		    's|^\(v[0-9][0-9]*\.[0-9][0-9]*\)\([^.].*\)\?$|\1.0\2|']),
+	m4_esyscmd([build-aux/git-version-gen $(echo '$Format:%h??%D$'\
+	            | sed -ne 's/^[$]Format:[^$]*[$]$/.tarball-version/p;tend'\
+	                  -e 's/.*tag: v\([^, ][^, ]*\).*/\1-yank/;tv'\
+	                  -e 's/^\([[:xdigit:]][[:xdigit:]]*\).*/1.0.3-yank\1/'\
+	                  -e ':v;w .snapshot-version' -e 'i .snapshot-version'\
+	                  -e ':end;q')\
+	              's/^\(v[0-9][0-9]*\.[0-9][0-9]*\)\([^.].*\)\?$/\1.0\2/']),
 	[developers@clusterlabs.org])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_SRCDIR([lib/ringbuffer.c])


### PR DESCRIPTION
This is meant as a lean, customized policy driven alternative
to the original proposal by Jan Friesse <jfriesse@redhat.com> that
balances the inherent trade-off in the opposite direction, so that the
configure.ac script is practically untouched and more weight and policy
is hardcoded in git-version-gen.  Problem with that approach stems from
(avoidable) effective fork of the respective gnulib's module and imposed
maintenance burden.

Speaking for libqb in particular, we should nonetheless make it
absolutely clear such in-development snapshots are nothing more,
nothing binding (not to think of viral injection of these bits
into circle of dependent packages upon their rebuilds), since the
changes accumulated since the last official release should only be
assumed firmly committed at the point the new release is cut (may
happen 99% of time with snapshots but no accountability from our
side for the complementary inter-release twists...), which is exactly
when many possibly unanticipated variables like correct SONAME
versions get to reflect what's appropriate.
Also, OpenPGP signature constitutes something more eligible for
one's trust than (provably) bit/content unstable archives without
the possibility of an independent authenticity/integrity verification.

  Therefore, the only thinkable and upstream-approved use cases
  for such snapshots are development-only purposes (CI et al.)!

Signed-off-by: Jan Pokorný <jpokorny@redhat.com>