### PR TITLE
configure: Fixed the problem that librt was explicitly needed in RHEL 6

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -144,6 +144,10 @@ AX_SAVE_FLAGS
 AC_SEARCH_LIBS([gethostbyname], [nsl],,[AC_MSG_ERROR([cannot find gethostbyname() function])])
 AC_SUBST([nsl_LIBS],[$LIBS])
 AX_RESTORE_FLAGS
+AX_SAVE_FLAGS
+AC_SEARCH_LIBS([clock_gettime], [rt],,[AC_MSG_ERROR([cannot find clock_gettime() function])])
+AC_SUBST([rt_LIBS],[$LIBS])
+AX_RESTORE_FLAGS
 
 # look for testing harness "check"
 PKG_CHECK_MODULES([CHECK], [check >= 0.9.4],[with_check=yes],[with_check=no])
@@ -207,6 +211,8 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
                     ]
                  )
 
+AX_SAVE_FLAGS
+LIBS="$LIBS $rt_LIBS"
 AC_MSG_CHECKING(for a working clock_getres(CLOCK_MONOTONIC, &ts))
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
 [[#include <time.h>]],
@@ -219,6 +225,8 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
                       AC_MSG_RESULT([no])
                     ]
                  )
+AC_CHECK_FUNCS([clock_gettime])
+AX_RESTORE_FLAGS
 
 
 # Checks for library functions
@@ -226,8 +234,7 @@ AC_FUNC_CHOWN
 AC_FUNC_FORK
 AC_FUNC_MMAP
 AC_FUNC_STRERROR_R
-AC_CHECK_FUNCS([alarm clock_gettime \
-		fsync fdatasync ftruncate \
+AC_CHECK_FUNCS([alarm fsync fdatasync ftruncate \
 		gettimeofday localtime localtime_r \
 		memset munmap socket \
 		strchr strrchr strdup strstr strcasecmp \

--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -78,7 +78,7 @@ EXTRA_DIST		= qblog_script.ld.in qblog_script.la.in qblog_script_noop.ld
 
 libqb_la_SOURCES	= $(source_to_lint) unix.c
 libqb_la_CFLAGS		= $(PTHREAD_CFLAGS)
-libqb_la_LIBADD		= $(LTLIBOBJS) $(dlopen_LIBS) $(PTHREAD_LIBS) $(socket_LIBS)
+libqb_la_LIBADD		= $(LTLIBOBJS) $(dlopen_LIBS) $(PTHREAD_LIBS) $(socket_LIBS) $(rt_LIBS)
 
 AM_LDFLAGS 	= $(LDFLAGS_COPY:-Bsymbolic-functions=)
 


### PR DESCRIPTION
We are building libqb in RHEL 6.
Although there was no problem up to v.1.0.1, since "AC_SEARCH_LIBS ([mq_open], [rt])" was deleted by the following modification, -lrt does not enter LIBS.
Therefore, in RHEL 6, HAVE_MONOTONIC_CLOCK is no longer defined from v 1.0.2.
https://github.com/ClusterLabs/libqb/commit/cb5ee921c04bfba24edf8b6f128d11161d161cec

Below is the information at v1.0.2 build time.
FYI: Since autogen.sh fails with the combination of v1.0.2 and RHEL6, we backport 9b50aa4.
```
[root@416fc3aee587 libqb]# git clean -d -x -f; git checkout v1.0.2 -f
HEAD is now at 608de6d... lib: update library version for upcoming 1.0.2 release
[root@416fc3aee587 libqb]# curl -OL https://github.com/ClusterLabs/libqb/commit/9b50aa4e5b84f495207b3f6185a1d6cb68af3f6d.patch && patch -d . -p1 < 9b50aa4e5b84f495207b3f6185a1d6cb68af3f6d.patch
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
103   618    0   618    0     0    773      0 --:--:-- --:--:-- --:--:--   929
patching file m4/ax_compat.m4
[root@416fc3aee587 libqb]# ./autogen.sh && ./configure
(snip)
[root@416fc3aee587 libqb]# less config.log
(snip)
configure:20863: checking for a working clock_getres(CLOCK_MONOTONIC, &ts)
configure:20895: gcc -std=gnu99 -o conftest -g -O2   conftest.c  >&5
/tmp/ccHTz3Ft.o: In function `main':
/usr/local/src/repo/libqb/conftest.c:69: undefined reference to `clock_getres'
collect2: ld returned 1 exit status
configure:20899: $? = 1
(snip)
configure:22464: checking for clock_gettime
configure:22520: gcc -std=gnu99 -o conftest -g -O2   conftest.c  >&5
/tmp/ccHFUrj5.o: In function `main':
/usr/local/src/repo/libqb/conftest.c:113: undefined reference to `clock_gettime'
collect2: ld returned 1 exit status
configure:22527: $? = 1
```