### PR TITLE
Journal logging followup

### DIFF
--- a/include/qb/qblog.h
+++ b/include/qb/qblog.h
@@ -618,6 +618,15 @@ void qb_log_tags_stringify_fn_set(qb_log_tags_stringify_fn fn);
 /**
  * Set the format specifiers.
  *
+ * @param t target
+ * @param format Format specifier per specification below,
+ *               @c NULL and empty string have their own,
+ *               distinct default-resetting semantics, you
+ *               shall only use the former (the latter is
+ *               a "hard" default override with @c QB_LOG_SYSLOG
+ *               in @cQB_LOG_CONF_USE_JOURNAL context and as
+ *               such backward-incompatible).
+ *
  * %n FUNCTION NAME
  * %f FILENAME
  * %l FILELINE
@@ -633,11 +642,11 @@ void qb_log_tags_stringify_fn_set(qb_log_tags_stringify_fn fn);
  * Any number between % and character specify field length to pad or chop.
  *
  * @note Some of the fields are immediately evaluated and remembered
- *       for performance reasons, so whenlog messages carry PIDs (not the default)
- *       this function needs to be reinvoked following @c fork
- *       (@c clone) in the respective children.  When already linking
- *       with @c libpthread, @c pthread_atfork callback registration
- *       could be useful.
+ *       for performance reasons, so when log messages carry PIDs
+ *       (not the default) this function needs to be reinvoked following
+ *       @c fork (@c clone) in the respective children.  When already
+ *       linking with @c libpthread, @c pthread_atfork callback
+ *       registration could be useful.
  */
 void qb_log_format_set(int32_t t, const char* format);
 

--- a/lib/log.c
+++ b/lib/log.c
@@ -1102,6 +1102,7 @@ qb_log_ctl2(int32_t t, enum qb_log_conf c, qb_log_ctl2_arg_t arg_not4directuse)
 #ifdef USE_JOURNAL
 		if (t == QB_LOG_SYSLOG) {
 			conf[t].use_journal = arg_i32;
+			qb_log_format_set(t, NULL);
 			need_reload = QB_TRUE;
 		} else {
 			rc = -EINVAL;

--- a/lib/log.c
+++ b/lib/log.c
@@ -1102,6 +1102,7 @@ qb_log_ctl2(int32_t t, enum qb_log_conf c, qb_log_ctl2_arg_t arg_not4directuse)
 #ifdef USE_JOURNAL
 		if (t == QB_LOG_SYSLOG) {
 			conf[t].use_journal = arg_i32;
+			need_reload = QB_TRUE;
 		} else {
 			rc = -EINVAL;
 		}

--- a/lib/log_syslog.c
+++ b/lib/log_syslog.c
@@ -97,8 +97,8 @@ _syslog_reload(int32_t target)
 {
 	struct qb_log_target *t = qb_log_target_get(target);
 
+	closelog();
 	if (!t->use_journal) {
-		closelog();
 		openlog(t->name, LOG_PID, t->facility);
 	}
 }


### PR DESCRIPTION
Additional point for discussion:

- for 2.0, it would perhaps make sense to drop the priority
  stringification from the implicit message structure for
  general syslog (and blackbox) target like I do here for its
  specialization, journal target (it's all _metadata_ rather then
  explicit marking -- that's suitable for plain/raw formats only,
  IMHO)