### PR TITLE
Test rpm

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -37,9 +37,6 @@ MAINTAINERCLEANFILES	= Makefile.in aclocal.m4 configure depcomp \
 
 ACLOCAL_AMFLAGS		= -I m4
 
-# For test suite
-export SOCKETDIR
-
 dist_doc_DATA		= COPYING INSTALL README.markdown
 
 SUBDIRS			= include lib docs tools tests examples

--- a/configure.ac
+++ b/configure.ac
@@ -557,6 +557,17 @@ AC_ARG_WITH([force-sockets-config-file],
 	[ FORCESOCKETSFILE="$withval" ],
 	[ FORCESOCKETSFILE="$sysconfdir/libqb/force-filesystem-sockets" ])
 
+AC_ARG_ENABLE([install-tests],
+  [AS_HELP_STRING([--enable-install-tests],[install tests])],,
+  [ enable_install_tests="no" ])
+AM_CONDITIONAL([INSTALL_TESTS], [test x$enable_install_tests = xyes])
+
+AC_ARG_WITH([testdir],
+  [AS_HELP_STRING([--with-testdir=DIR],[path to /usr/lib../libqb/tests/ dir where to install the test suite])],
+        [ TESTDIR="$withval" ],
+        [ TESTDIR="$libdir/libqb/tests" ])
+AC_SUBST([TESTDIR])
+
 AC_SUBST(CP)
 # *FLAGS handling goes here
 

--- a/libqb.spec.in
+++ b/libqb.spec.in
@@ -1,4 +1,5 @@
 %bcond_without check
+%bcond_without testsrpm
 
 %global alphatag @alphatag@
 %global numcomm @numcomm@
@@ -26,7 +27,11 @@ and polling.
 
 %build
 ./autogen.sh
-%configure --disable-static
+%configure \
+%if %{with testsrpm}
+ --enable-install-tests \
+%endif
+ --disable-static
 make %{?_smp_mflags}
 
 %if 0%{?with_check}
@@ -65,6 +70,20 @@ developing applications that use %{name}.
 %{_libdir}/libqb.so
 %{_libdir}/pkgconfig/libqb.pc
 %{_mandir}/man3/qb*3*
+
+%if %{with testsrpm}
+%package	tests
+Summary:        Test suite for %{name}
+Group:          Development/Libraries
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%files		tests
+%doc COPYING
+%{_libdir}/libqb/tests/*
+
+%description	tests
+The %{name}-tests package contains the %{name} test suite.
+%endif
 
 %changelog
 * @date@ Autotools generated version <nobody@nowhere.org> - @version@-1-@numcomm@.@alphatag@.@dirty@

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -132,6 +132,12 @@ TESTS += util.test
 check_PROGRAMS += util.test
 endif
 
+if INSTALL_TESTS
+testsuitedir	= $(TESTDIR)
+testsuite_PROGRAMS = $(check_PROGRAMS)
+testsuite_SCRIPTS = $(dist_check_SCRIPTS) test.conf
+endif
+
 file_change_bytes_SOURCES = file_change_bytes.c
 
 crash_test_dummy_SOURCES = crash_test_dummy.c

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -24,7 +24,8 @@ CLEANFILES =
 AM_CPPFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include
 
 noinst_PROGRAMS = bmc bmcpt bms rbreader rbwriter \
-	bench-log format_compare_speed loop print_ver
+	bench-log format_compare_speed loop print_ver \
+	$(check_PROGRAMS)
 
 noinst_HEADERS = check_common.h
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -21,6 +21,8 @@ MAINTAINERCLEANFILES = Makefile.in
 EXTRA_DIST =
 CLEANFILES =
 
+export SOCKETDIR
+
 AM_CPPFLAGS = -I$(top_builddir)/include -I$(top_srcdir)/include
 
 noinst_PROGRAMS = bmc bmcpt bms rbreader rbwriter \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -118,6 +118,7 @@ EXTRA_DIST += start.test resources.test
 EXTRA_DIST += blackbox-segfault.sh
 
 TESTS = start.test array.test map.test rb.test list.test log.test blackbox-segfault.sh loop.test ipc.test resources.test
+TESTS_ENVIRONMENT = export PATH=.:../tools:$$PATH;
 
 resources.log: rb.log log.log ipc.log
 

--- a/tests/blackbox-segfault.sh
+++ b/tests/blackbox-segfault.sh
@@ -1,6 +1,17 @@
 #!/bin/sh
 #
 # create a normal blackbox
+
+# use in-tree qb-blackbox when available
+if [ -f ../tools/qb-blackbox ]; then
+ QBBLACKBOX=../tools/qb-blackbox
+else
+ QBBLACKBOX=qb-blackbox
+fi
+
+#
+# create a normal blackbox
+#
 rm -f crash-test-dummy.fdata
 ./crash_test_dummy
 rm -f core*
@@ -9,18 +20,17 @@ rm -f core*
 
 # first test that reading the valid
 # blackbox data actually works.
-../tools/qb-blackbox crash-test-dummy.fdata
+$QBBLACKBOX crash-test-dummy.fdata
 if [ $? -ne 0 ]; then
 	exit 1
 fi
-
 
 for i in $(seq $NUM_BB_TESTS)
 do
     rm -f butchered_blackbox.fdata
     echo " ==== Corrupt blackbox test $i/$NUM_BB_TESTS ===="
     ./file_change_bytes -i crash-test-dummy.fdata -o butchered_blackbox.fdata -n 1024
-    ../tools/qb-blackbox butchered_blackbox.fdata
+    $QBBLACKBOX butchered_blackbox.fdata
     [ $? -gt 127 ] && exit 1 || true
 done
 

--- a/tests/blackbox-segfault.sh
+++ b/tests/blackbox-segfault.sh
@@ -1,26 +1,24 @@
 #!/bin/sh
 #
+# Needs PATH to be set to find accompanying test programs
+# - including qb-blackbox which for in-tree tests should be
+# - in ../tools
+#
 # create a normal blackbox
-
-# use in-tree qb-blackbox when available
-if [ -f ../tools/qb-blackbox ]; then
- QBBLACKBOX=../tools/qb-blackbox
-else
- QBBLACKBOX=qb-blackbox
-fi
+#
 
 #
 # create a normal blackbox
 #
 rm -f crash-test-dummy.fdata
-./crash_test_dummy
+crash_test_dummy
 rm -f core*
 
-. ./test.conf
+. test.conf
 
 # first test that reading the valid
 # blackbox data actually works.
-$QBBLACKBOX crash-test-dummy.fdata
+qb-blackbox crash-test-dummy.fdata
 if [ $? -ne 0 ]; then
 	exit 1
 fi
@@ -29,8 +27,8 @@ for i in $(seq $NUM_BB_TESTS)
 do
     rm -f butchered_blackbox.fdata
     echo " ==== Corrupt blackbox test $i/$NUM_BB_TESTS ===="
-    ./file_change_bytes -i crash-test-dummy.fdata -o butchered_blackbox.fdata -n 1024
-    $QBBLACKBOX butchered_blackbox.fdata
+    file_change_bytes -i crash-test-dummy.fdata -o butchered_blackbox.fdata -n 1024
+    qb-blackbox butchered_blackbox.fdata
     [ $? -gt 127 ] && exit 1 || true
 done
 


### PR DESCRIPTION
allow building and shipping of libqb test suite, both from the local build and as rpm.

the patchset includes a partial example on what needs to be fixed in the test suite to run on an installed system. There are several bits that needs fixing because the test suite assume that it´s being executed from the build tree and have write access to ./
