### PR TITLE
WIP: use mkdtemp for IPC paths

### DIFF
--- a/lib/ipc_socket.c
+++ b/lib/ipc_socket.c
@@ -577,7 +577,7 @@ qb_ipcc_us_connect(struct qb_ipcc_connection * c,
 	c->funcs.disconnect = qb_ipcc_us_disconnect;
 
 	fd_hdr = qb_sys_mmap_file_open(path, r->request,
-				       SHM_CONTROL_SIZE, O_RDWR);
+				       SHM_CONTROL_SIZE, O_RDWR, NULL);
 	if (fd_hdr < 0) {
 		res = fd_hdr;
 		errno = -fd_hdr;
@@ -790,7 +790,7 @@ qb_ipcs_us_connect(struct qb_ipcs_service *s,
 
 	fd_hdr = qb_sys_mmap_file_open(path, r->request,
 				       SHM_CONTROL_SIZE,
-				       O_CREAT | O_TRUNC | O_RDWR);
+				       O_CREAT | O_TRUNC | O_RDWR, NULL);
 	if (fd_hdr < 0) {
 		res = fd_hdr;
 		errno = -fd_hdr;

--- a/lib/unix.c
+++ b/lib/unix.c
@@ -56,10 +56,12 @@ qb_strerror_r(int errnum, char *buf, size_t buflen)
 static int32_t
 open_mmap_file(char *path, uint32_t file_flags)
 {
-	if (strstr(path, "XXXXXX") != NULL) {
-		mode_t old_mode = umask(077);
+	const char *last_X;
+	if ((last_X = strrchr(path, 'X')) != NULL && last_X + 1 == '\0'
+			&& last_X - path >= 5 && strspn(last_X - 5, 'X') >= 6) {
+		mode_t old_mode = umask(177);
 		int32_t temp_fd = mkstemp(path);
-		(void)umask(old_mode);
+		(void) umask(old_mode);
 		return temp_fd;
 	}
 

--- a/lib/util_int.h
+++ b/lib/util_int.h
@@ -60,10 +60,11 @@
  * @param file (in) the name of the file to be used.
  * @param bytes the size to truncate the file to.
  * @param file_flags same as passed into open()
+ * @parent_dir_fd pointer to opened (O_SEARCH) directory if any
  * @return 0 (success) or -errno
  */
 int32_t qb_sys_mmap_file_open(char *path, const char *file, size_t bytes,
-			       uint32_t file_flags);
+                              uint32_t file_flags, int32_t *parent_dir_fd);
 
 /**
  * Create a shared mamory circular buffer.


### PR DESCRIPTION
work in progress:

* [x] core implementation
* [ ] code cleanup, doc, valgrind sanitization etc.
* [ ] `chmod` + `chown` recursion, also reconsider the permissions
       scheme (single perms guard at the dir + lax approach for items,
       vs. everything strict) and sanity checking
       (`data` contained within the same parent dir `header`
       enforcement in client)
* [ ] `rmdir` at more places as a proper cleanup 
* [ ] using `gnulib` surrogate for `mkdtemp` where not available natively