### PR TITLE
Faster IPC tests on *BSD

### DIFF
--- a/tests/check_ipc.c
+++ b/tests/check_ipc.c
@@ -611,6 +611,13 @@ s1_connection_closed(qb_ipcs_connection_t *c)
 	if (multiple_connections) {
 		return 0;
 	}
+	/* Stop the connection being freed when we call qb_ipcs_disconnect()
+	   in the callback */
+	if (disconnect_after_created == QB_TRUE) {
+		disconnect_after_created = QB_FALSE;
+		return 1;
+	}
+
 	qb_enter();
 	qb_leave();
 	return 0;

--- a/tests/check_ipc.c
+++ b/tests/check_ipc.c
@@ -44,6 +44,13 @@
 #include "_failure_injection.h"
 #endif
 
+/* The stress test takes over an hour on FreeBSD otherwise */
+#if defined(QB_BSD)
+#define NUM_STRESS_CONNECTIONS 7000
+#else
+#define NUM_STRESS_CONNECTIONS 70000
+#endif
+
 static char ipc_name[256];
 
 #define DEFAULT_MAX_MSG_SIZE (8192*16)
@@ -1414,7 +1421,7 @@ test_ipc_stress_connections(void)
 	pid = run_function_in_new_process("server", run_ipc_server, NULL);
 	fail_if(pid == -1);
 
-	for (connections = 1; connections < 70000; connections++) {
+	for (connections = 1; connections < NUM_STRESS_CONNECTIONS; connections++) {
 		if (conn) {
 			qb_ipcc_disconnect(conn);
 			conn = NULL;


### PR DESCRIPTION
[turning the on-project branch into a regular PR so the discussion can
be had at all, that being said, would be entirely fine with old good
ML driven development, either using developers@cl.o or a new dedicated
list if PRs are not seen that viable]

This tries to nail the problem I added a cursory `/* ? */` comment at
recently.

Is it really the matter of *BSD being slow, or is it a systemic problem
of libqb (or the test code) exercising the something in a not-optimized-for
fashion?  I mean, VMs are of about the same speed, so it's natural
the differences amongst OSes will be minimal, but that apparently is not
the case.

Lowering the number of iteration is a big hammer to use when we are
out of ideas, I think.  Is it the case already?