### PR TITLE
ipc: fix force-filesystem-sockets

### DIFF
--- a/lib/ipc_socket.c
+++ b/lib/ipc_socket.c
@@ -71,7 +71,7 @@ set_sock_addr(struct sockaddr_un *address, const char *socket_name)
 	address->sun_len = QB_SUN_LEN(address);
 #endif
 
-	if (!use_filesystem_sockets()) {
+	if (socket_name[0] == '/' || !use_filesystem_sockets()) {
 		snprintf(address->sun_path + 1, UNIX_PATH_MAX - 1, "%s", socket_name);
 	} else {
 		snprintf(address->sun_path, sizeof(address->sun_path), "%s/%s", SOCKETDIR,


### PR DESCRIPTION
the /etc/libqb/force-filesystem-sockets option got broken for some
applications in the last security update.