### PR TITLE
Improve speed of IPC tests

### DIFF
--- a/lib/loop_poll_kqueue.c
+++ b/lib/loop_poll_kqueue.c
@@ -153,8 +153,6 @@ retry_poll:
 			revents |= POLLERR;
 		}
 		if (events[i].flags & EV_EOF) {
-			qb_util_log(LOG_INFO,
-				    "got EV_EOF on fd %d.", pe->ufd.fd);
 			revents |= POLLHUP;
 		}
 		if (events[i].filter == EVFILT_READ) {

--- a/tests/check_ipc.c
+++ b/tests/check_ipc.c
@@ -44,6 +44,8 @@
 #include "_failure_injection.h"
 #endif
 
+#define NUM_STRESS_CONNECTIONS 5000
+
 static char ipc_name[256];
 
 #define DEFAULT_MAX_MSG_SIZE (8192*16)
@@ -604,6 +606,13 @@ s1_connection_closed(qb_ipcs_connection_t *c)
 	if (multiple_connections) {
 		return 0;
 	}
+	/* Stop the connection being freed when we call qb_ipcs_disconnect()
+	   in the callback */
+	if (disconnect_after_created == QB_TRUE) {
+		disconnect_after_created = QB_FALSE;
+		return 1;
+	}
+
 	qb_enter();
 	qb_leave();
 	return 0;
@@ -1414,7 +1423,7 @@ test_ipc_stress_connections(void)
 	pid = run_function_in_new_process("server", run_ipc_server, NULL);
 	fail_if(pid == -1);
 
-	for (connections = 1; connections < 70000; connections++) {
+	for (connections = 1; connections < NUM_STRESS_CONNECTIONS; connections++) {
 		if (conn) {
 			qb_ipcc_disconnect(conn);
 			conn = NULL;


### PR DESCRIPTION
Reduce the number of iterations from 70000 to 5000. For what it's testing (multiple connections) the extra large number doesn't tell us anything significant, and just adds to the load on the CI and build systems - especially BSD but also the slower Linux systems. This has been a collegiate decision after discussion on IRC.

The EV_EOF message has been removed from the FreeBSD kqueue code - there is no equivalent of this on the epoll side and, again, it just slowed things down.

There's also a user-after-free bugfix to test_ipc_disconnect_after_created(), which currently only affects BSD but in theory could trigger anywhere.