### PR TITLE
tests: Run IPC with use-filesystem-sockets active

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -113,11 +113,16 @@ endif
 bench_log_SOURCES = bench-log.c
 bench_log_LDADD = $(top_builddir)/lib/libqb.la
 
+lib_LTLIBRARIES = libstat_wrapper.la
+libstat_wrapper_la_SOURCES = libstat_wrapper.c
+libstat_wrapper_la_LIBADD = -ldl
+libdir= $(TESTDIR)
+
 if HAVE_CHECK
-EXTRA_DIST += start.test resources.test
+EXTRA_DIST += start.test resources.test ipc_sock.test
 EXTRA_DIST += blackbox-segfault.sh
 
-TESTS = start.test array.test map.test rb.test list.test log.test blackbox-segfault.sh loop.test ipc.test resources.test
+TESTS = start.test array.test map.test rb.test list.test log.test blackbox-segfault.sh loop.test ipc.test ipc_sock.test resources.test
 TESTS_ENVIRONMENT = export PATH=.:../tools:$$PATH;
 
 resources.log: rb.log log.log ipc.log
@@ -126,7 +131,7 @@ check_LTLIBRARIES =
 check_PROGRAMS = array.test ipc.test list.test log.test loop.test \
 		 map.test rb.test util.test \
 		 crash_test_dummy file_change_bytes
-dist_check_SCRIPTS = start.test resources.test blackbox-segfault.sh
+dist_check_SCRIPTS = start.test resources.test blackbox-segfault.sh ipc_sock.test
 
 if HAVE_SLOW_TESTS
 TESTS += util.test

--- a/tests/ipc_sock.test
+++ b/tests/ipc_sock.test
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+# Run the IPC tests under the stat wrapper,
+# this simulates /etc/libqb/use-filesystem-sockets existing
+# so we can test both options without breaking other things
+# that might be running on this system
+#
+if [ "`uname -s`" = "Linux" ]
+then
+  if [ -f `pwd`/.libs/libstatwrapper.so ]
+  then
+    export LD_PRELOAD=`pwd`/.libs/libstat_wrapper.so
+  else
+    export LD_PRELOAD=`pwd`/libstat_wrapper.so
+  fi
+  ./ipc.test
+else
+  exit 0
+fi

--- a/tests/libstat_wrapper.c
+++ b/tests/libstat_wrapper.c
@@ -1,0 +1,35 @@
+/*
+ * Simulate FORCESOCKETSFILE existing for the IPC tests
+ */
+
+#include <stdio.h>
+#include <dlfcn.h>
+#include <string.h>
+#include <sys/stat.h>
+#include "../include/config.h"
+#if defined(QB_LINUX) || defined(QB_CYGWIN)
+#include <gnu/lib-names.h>
+#endif
+
+int __xstat(int __ver, const char *__filename, struct stat *__stat_buf)
+{
+#if defined(QB_LINUX) || defined(QB_CYGWIN)
+	static int opened = 0;
+	static void *dlhandle;
+	static int (*real_xstat)(int __ver, const char *__filename, void *__stat_buf);
+
+	if (!opened) {
+		dlhandle = dlopen(LIBC_SO, RTLD_NOW);
+		real_xstat = dlsym(dlhandle, "__xstat");
+		opened = 1;
+	}
+
+	if (strcmp(__filename, FORCESOCKETSFILE) == 0) {
+		return 0; /* it exists! */
+	}
+
+	return real_xstat(__ver, __filename, __stat_buf);
+#else
+	return -1; /* Error in the unlikely event we get called on *BSD* */
+#endif
+}


### PR DESCRIPTION
Provide an LD_PRELOAD library that simulates the presence
of /etc/libqb/use-filesystem-sockets so that we can test
that functionality without actually having the file on
the system and affecting everything else running on the
box.

NOT FOR MERGING YET. scripts need testing on other arches at least