### PR TITLE
Set correct ownership if qb_ipcs_connection_auth_set() has been used

### DIFF
--- a/lib/ipc_setup.c
+++ b/lib/ipc_setup.c
@@ -660,11 +660,12 @@ handle_new_connection(struct qb_ipcs_service *s,
 		res = -errno;
 		goto send_response;
 	}
-	res = chown(c->description, c->auth.uid, c->auth.gid);
-	if (res != 0) {
+	if (chmod(c->description, 0770)) {
 		res = -errno;
 		goto send_response;
 	}
+	/* chown can fail because we might not be root */
+	(void)chown(c->description, c->auth.uid, c->auth.gid);
 
 	/* We can't pass just a directory spec to the clients */
 	strncat(c->description,"/qb", CONNECTION_DESCRIPTION);

--- a/lib/ipc_setup.c
+++ b/lib/ipc_setup.c
@@ -657,12 +657,12 @@ handle_new_connection(struct qb_ipcs_service *s,
 	snprintf(c->description, CONNECTION_DESCRIPTION,
 		 "/dev/shm/qb-%d-%d-%d-XXXXXX", s->pid, ugp->pid, c->setup.u.us.sock);
 	if (mkdtemp(c->description) == NULL) {
-		res = errno;
+		res = -errno;
 		goto send_response;
 	}
 	res = chown(c->description, c->auth.uid, c->auth.gid);
 	if (res != 0) {
-		res = errno;
+		res = -errno;
 		goto send_response;
 	}
 

--- a/lib/ipc_shm.c
+++ b/lib/ipc_shm.c
@@ -312,6 +312,8 @@ qb_ipcs_shm_connect(struct qb_ipcs_service *s,
 		    struct qb_ipc_connection_response *r)
 {
 	int32_t res;
+	char dirname[PATH_MAX];
+	char *slash;
 
 	qb_util_log(LOG_DEBUG, "connecting to client [%d]", c->pid);
 
@@ -321,6 +323,14 @@ qb_ipcs_shm_connect(struct qb_ipcs_service *s,
 		 c->description, s->name);
 	snprintf(r->event, NAME_MAX, "%s-event-%s",
 		 c->description, s->name);
+
+	/* Set correct ownership if qb_ipcs_connection_auth_set() has been used */
+	strlcpy(dirname, c->description, sizeof(dirname));
+	slash = strrchr(dirname, '/');
+	if (slash) {
+		*slash = '\0';
+		(void)chown(dirname, c->auth.uid, c->auth.gid);
+	}
 
 	res = qb_ipcs_shm_rb_open(c, &c->request,
 				  r->request);


### PR DESCRIPTION
- The temporary directory that is used since 6a4067c1d1764d93d255eccecfd8bf9f43cb0b4d needs to be accessible by the group as well. This has been fixed on the [version_1](https://github.com/ClusterLabs/libqb/tree/version_1) branch (and in version 1.0.5) by 65d6fb37a28f3b41f2e73c49214a4c9e3533f15a, but not on master. Cherry-pick this fix (as well as another related fix to make the patch apply cleanly) for master.
- When [`qb_ipcs_connection_auth_set`](https://github.com/ClusterLabs/libqb/blob/6a4067c1d1764d93d255eccecfd8bf9f43cb0b4d/lib/ipcs.c#L938-L946) is used, the ownership of the temporary directory that is initially set in [`handle_new_connection`](https://github.com/ClusterLabs/libqb/blob/7f891f0069623edc0b2212bf559e70fa56ba5c12/lib/ipc_setup.c#L663) must be updated as well, so do this at the beginning of [`qb_ipcs_shm_connect`](https://github.com/ClusterLabs/libqb/blob/7f891f0069623edc0b2212bf559e70fa56ba5c12/lib/ipc_shm.c#L310).

This pull request fixes USBGuard/usbguard#289: when running USBGuard without the `CAP_DAC_OVERRIDE` capability (as done by the provided system service or by running `usbguard-daemon -C` to drop unnecessary capabilities), the temporary directory cannot be accessed because its group ownership is set to the user of the IPC client despite USBGuard using [`qb_ipcs_connection_auth_set(conn, uid, 0, 0660)`](https://github.com/USBGuard/usbguard/blob/50c99211d512b963a8bcf271e316b65b967ab585/src/Library/IPCServerPrivate.cpp#L261) to set the gid to root. As a result, all IPC communication with non-root users is broken.

Fixes: #369