### PR TITLE
[version_1] Set correct ownership if qb_ipcs_connection_auth_set() has been used

### DIFF
--- a/lib/Makefile.am
+++ b/lib/Makefile.am
@@ -151,7 +151,7 @@ ALL_LINT_FLAGS = $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(DEB_INCLUDES) \
 # ipc_setup.c: (in function qb_ipcc_us_setup_connect)
 # ipc_setup.c:479:2: Return value (type int32_t) ignored: qb_ipc_us_ready(...
 # ipc_setup.c:494:2: Return value (type int32_t) ignored: qb_ipc_auth_cred...
-SPLINT_SUMMARY_EXP = " 2 code warnings"
+SPLINT_SUMMARY_EXP = " 3 code warnings"
 
 run_splint.sh: $(top_srcdir)/configure.ac
 	@echo '$(SPLINT) $(ALL_LINT_FLAGS) \' > $@-t

--- a/lib/ipc_shm.c
+++ b/lib/ipc_shm.c
@@ -283,6 +283,8 @@ qb_ipcs_shm_connect(struct qb_ipcs_service *s,
 		    struct qb_ipc_connection_response *r)
 {
 	int32_t res;
+	char dirname[PATH_MAX];
+	char *slash;
 
 	qb_util_log(LOG_DEBUG, "connecting to client [%d]", c->pid);
 
@@ -292,6 +294,14 @@ qb_ipcs_shm_connect(struct qb_ipcs_service *s,
 		 c->description, s->name);
 	snprintf(r->event, NAME_MAX, "%s-event-%s",
 		 c->description, s->name);
+
+	/* Set correct ownership if qb_ipcs_connection_auth_set() has been used */
+	strlcpy(dirname, c->description, sizeof(dirname));
+	slash = strrchr(dirname, '/');
+	if (slash) {
+		*slash = '\0';
+		(void)chown(dirname, c->auth.uid, c->auth.gid);
+	}
 
 	res = qb_ipcs_shm_rb_open(c, &c->request,
 				  r->request);


### PR DESCRIPTION
Backport #381 in case there is another 1.0.* release.