### PR TITLE
qblist: Retype ptr in qb_list_entry to char*

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -601,6 +601,7 @@ WARNLIST="
 	suggest-attribute=format
 	property-attribute-mismatch
 	strict-prototypes
+	pointer-arith
 	write-strings
 	cast-align
 	bad-function-cast

--- a/include/qb/qblist.h
+++ b/include/qb/qblist.h
@@ -195,7 +195,7 @@ static inline void qb_list_splice_tail(struct qb_list_head *list,
  * @param member:	the name of the list_struct within the struct.
  */
 #define qb_list_entry(ptr,type,member) ({	       \
-	((type *)((void*)ptr - offsetof(type, member))); })
+	((type *)((char*)ptr - offsetof(type, member))); })
 
 /**
  * Get the first element from a list


### PR DESCRIPTION
This allows pointer arithmetics without issuing warning.

Signed-off-by: Jan Friesse <jfriesse@redhat.com>