### PR TITLE
trie: Don't assume that chars are unsigned < 126

### DIFF
--- a/lib/trie.c
+++ b/lib/trie.c
@@ -64,8 +64,8 @@ static void trie_destroy_node(struct trie_node *node);
  * characters are stored in reverse to make accessing the
  * more common case (non-control chars) more space efficient.
  */
-#define TRIE_CHAR2INDEX(ch) abs(126 - ch)
-#define TRIE_INDEX2CHAR(idx) abs(126 - idx)
+#define TRIE_CHAR2INDEX(ch) (127 - (signed char)ch)
+#define TRIE_INDEX2CHAR(idx) (127 - (signed char)idx)
 
 
 static int32_t

--- a/lib/trie.c
+++ b/lib/trie.c
@@ -64,8 +64,8 @@ static void trie_destroy_node(struct trie_node *node);
  * characters are stored in reverse to make accessing the
  * more common case (non-control chars) more space efficient.
  */
-#define TRIE_CHAR2INDEX(ch) (126 - ch)
-#define TRIE_INDEX2CHAR(idx) (126 - idx)
+#define TRIE_CHAR2INDEX(ch) abs(126 - ch)
+#define TRIE_INDEX2CHAR(idx) abs(126 - idx)
 
 
 static int32_t

--- a/tests/check_map.c
+++ b/tests/check_map.c
@@ -50,7 +50,9 @@ const char *composers[] = {
 	"Benjamin Britten",
 	"Josef Haydn",
 	"Claude Debussy",
-	"Charles Ives"
+	"Charles Ives",
+	/* Maybe in an alien language ... but they can cause trie crashes & conflicts */
+	"\x7e\x7f\x80\x81", "\x7e", "\x7e\x7f", "\x7e\x7f\x80",
 };
 
 


### PR DESCRIPTION
Trie fails on systems with unsigned chars when using characters over
126.

This needs looking over and running through the CI systems - hence the PR