### PR TITLE
log: Fix threading races

### DIFF
--- a/lib/log_thread.c
+++ b/lib/log_thread.c
@@ -296,7 +296,9 @@ qb_log_thread_stop(void)
 			free(rec);
 		}
 	} else {
+		(void)qb_thread_lock(logt_wthread_lock);
 		wthread_should_exit = QB_TRUE;
+		(void)qb_thread_unlock(logt_wthread_lock);
 		sem_post(&logt_print_finished);
 		pthread_join(logt_thread_id, NULL);
 	}


### PR DESCRIPTION
It seems we can't avoiding locking in qb_log_dcs_get because
qb_array_get() isn't thread-safe.

Alternatives to this would be to add a - new - implementation of
the arrays or to stick the lock higher up (as in this patch).
We're logging here, so doing I/O, plus all the formatting
that goes on, I think the locking is a minimal intrusion on the CPU
relatively speaking.

This bug was seen in the test suite on BSD so it's not just theoretical

also wthread_should_exit was unprotected.