### PR TITLE
Add qb_ipcs_alias_create() function

### DIFF
--- a/examples/ipcclient.c
+++ b/examples/ipcclient.c
@@ -28,6 +28,7 @@
 
 static int32_t do_benchmark = QB_FALSE;
 static int32_t use_events = QB_FALSE;
+static int32_t use_alias = QB_FALSE;
 static int alarm_notice;
 static qb_util_stopwatch_t *sw;
 #define ONE_MEG 1048576
@@ -192,7 +193,7 @@ int
 main(int argc, char *argv[])
 {
 	qb_ipcc_connection_t *conn;
-	const char *options = "ebh";
+	const char *options = "eabh";
 	int32_t opt;
 
 	while ((opt = getopt(argc, argv, options)) != -1) {
@@ -202,6 +203,9 @@ main(int argc, char *argv[])
 			break;
 		case 'e':
 			use_events = QB_TRUE;
+			break;
+		case 'a':
+			use_alias = QB_TRUE;
 			break;
 		case 'h':
 		default:
@@ -222,7 +226,11 @@ main(int argc, char *argv[])
 	/* Our example server is enforcing a buffer size minimum,
 	 * so the client does not need to be concerned with setting
 	 * the buffer size */
-	conn = qb_ipcc_connect("ipcserver", 0);
+	if (use_alias) {
+		conn = qb_ipcc_connect("ipcserver_alias", 0);
+	} else {
+		conn = qb_ipcc_connect("ipcserver", 0);
+	}
 	if (conn == NULL) {
 		perror("qb_ipcc_connect");
 		exit(1);

--- a/examples/ipcserver.c
+++ b/examples/ipcserver.c
@@ -38,8 +38,10 @@ static qb_array_t *gio_map;
 
 static int32_t use_glib = QB_FALSE;
 static int32_t use_events = QB_FALSE;
+static int32_t use_alias = QB_FALSE;
 static qb_loop_t *bms_loop;
 static qb_ipcs_service_t *s1;
+static qb_ipcs_service_t *s2;
 
 static int32_t
 s1_connection_accept_fn(qb_ipcs_connection_t * c, uid_t uid, gid_t gid)
@@ -310,10 +312,10 @@ my_dispatch_del(int32_t fd)
 int32_t
 main(int32_t argc, char *argv[])
 {
-	const char *options = "mpseugh";
+	const char *options = "mpseuagh";
 	int32_t opt;
 	int32_t rc;
-	enum qb_ipc_type ipc_type = QB_IPC_NATIVE;
+	enum qb_ipc_type ipc_type = QB_IPC_SHM;
 	struct qb_ipcs_service_handlers sh = {
 		.connection_accept = s1_connection_accept_fn,
 		.connection_created = s1_connection_created_fn,
@@ -350,6 +352,9 @@ main(int32_t argc, char *argv[])
 		case 'e':
 			use_events = QB_TRUE;
 			break;
+		case 'a':
+			use_alias = QB_TRUE;
+			break;
 		case 'h':
 		default:
 			show_usage(argv[0]);
@@ -370,7 +375,16 @@ main(int32_t argc, char *argv[])
 		qb_perror(LOG_ERR, "qb_ipcs_create");
 		exit(1);
 	}
-	/* This forces the clients to use a minimum buffer size */
+	if (use_alias) {
+		s2 = qb_ipcs_alias_create(s1, "ipcserver_alias", ipc_type);
+		if (s2 == 0) {
+			qb_perror(LOG_ERR, "qb_ipcs_alias_create");
+			exit(1);
+		}
+	}
+
+
+/* This forces the clients to use a minimum buffer size */
 	qb_ipcs_enforce_buffer_size(s1, ONE_MEG);
 
 	if (!use_glib) {
@@ -382,6 +396,14 @@ main(int32_t argc, char *argv[])
 			qb_perror(LOG_ERR, "qb_ipcs_run");
 			exit(1);
 		}
+		if (use_alias) {
+			rc = qb_ipcs_run(s2);
+			if (rc != 0) {
+				errno = -rc;
+				qb_perror(LOG_ERR, "qb_ipcs_run");
+				exit(1);
+			}
+		}
 		qb_loop_run(bms_loop);
 	} else {
 #ifdef HAVE_GLIB
@@ -389,6 +411,12 @@ main(int32_t argc, char *argv[])
 		gio_map = qb_array_create_2(16, sizeof(struct gio_to_qb_poll), 1);
 		qb_ipcs_poll_handlers_set(s1, &glib_ph);
 		rc = qb_ipcs_run(s1);
+		if (rc != 0) {
+			errno = -rc;
+			qb_perror(LOG_ERR, "qb_ipcs_run");
+			exit(1);
+		}
+		rc = qb_ipcs_run(s2);
 		if (rc != 0) {
 			errno = -rc;
 			qb_perror(LOG_ERR, "qb_ipcs_run");

--- a/examples/ipcserver.c
+++ b/examples/ipcserver.c
@@ -123,6 +123,9 @@ s1_msg_process_fn(qb_ipcs_connection_t * c, void *data, size_t size)
 	qb_log(LOG_DEBUG, "msg received (id:%d, size:%d, data:%s)",
 	       req_pt->hdr.id, req_pt->hdr.size, req_pt->message);
 
+	if (strcmp(req_pt->message, "exit") == 0) {
+		qb_loop_stop(bms_loop);
+	}
 	if (strcmp(req_pt->message, "kill") == 0) {
 		exit(0);
 	}
@@ -428,6 +431,9 @@ main(int32_t argc, char *argv[])
 		       "You don't seem to have glib-devel installed.\n");
 #endif
 	}
+	/* Deliberately do this in the 'wrong' order to check for bugs */
+	qb_ipcs_destroy(s1);
+	qb_ipcs_destroy(s2);
 	qb_log_fini();
 	return EXIT_SUCCESS;
 }

--- a/include/qb/qbipcs.h
+++ b/include/qb/qbipcs.h
@@ -207,6 +207,20 @@ qb_ipcs_service_t* qb_ipcs_create(const char *name,
 
 
 /**
+ * Create an alias for an existing IPC server.
+ *
+ * @param name for clients to connect to.
+ * @param service existing service ref
+ * @param type transport type.
+ * @return the new service instance.
+ */
+
+qb_ipcs_service_t *
+qb_ipcs_alias_create(qb_ipcs_service_t *service,
+		     const char *name,
+		     enum qb_ipc_type type);
+
+/**
  * Increase the reference counter on the service object.
  *
  * @param s service instance

--- a/lib/ipc_int.h
+++ b/lib/ipc_int.h
@@ -151,6 +151,8 @@ struct qb_ipcs_service {
 	struct qb_list_head list;
 	struct qb_ipcs_stats stats;
 
+	qb_ipcs_service_t *alias_for; /* NULL if not an alias service */
+
 	void *context;
 };
 

--- a/lib/ipc_setup.c
+++ b/lib/ipc_setup.c
@@ -626,10 +626,12 @@ handle_new_connection(struct qb_ipcs_service *s,
 	struct qb_ipc_connection_request *req = msg;
 	int32_t res = auth_result;
 	int32_t res2 = 0;
-	uint32_t max_buffer_size = QB_MAX(req->max_msg_size, s->max_buffer_size);
+	uint32_t max_buffer_size;
 	struct qb_ipc_connection_response response;
 	const char suffix[] = "/qb";
 	int desc_len;
+
+	max_buffer_size = QB_MAX(req->max_msg_size, s->max_buffer_size);
 
 	c = qb_ipcs_connection_alloc(s);
 	if (c == NULL) {
@@ -691,8 +693,6 @@ handle_new_connection(struct qb_ipcs_service *s,
 		goto send_response;
 	}
 #endif
-
-
 
 	if (auth_result == 0 && c->service->serv_fns.connection_accept) {
 		res = c->service->serv_fns.connection_accept(c,

--- a/lib/ipcs.c
+++ b/lib/ipcs.c
@@ -85,40 +85,9 @@ qb_ipcs_alias_create(qb_ipcs_service_t *service,
 {
 	struct qb_ipcs_service *s;
 
-	s = calloc(1, sizeof(struct qb_ipcs_service));
-	if (s == NULL) {
-		return NULL;
-	}
-	if (type == QB_IPC_NATIVE) {
-#ifdef DISABLE_IPC_SHM
-		s->type = QB_IPC_SOCKET;
-#else
-		s->type = QB_IPC_SHM;
-#endif /* DISABLE_IPC_SHM */
-	} else {
-		s->type = type;
-	}
+	s = qb_ipcs_create(name, service->service_id, type, &service->serv_fns);
 
-	s->pid = getpid();
-	s->needs_sock_for_poll = QB_FALSE;
-	s->poll_priority = QB_LOOP_MED;
-
-	/* Initial alloc ref */
-	qb_ipcs_ref(s);
-
-	s->service_id = service->service_id;
-	(void)strlcpy(s->name, name, NAME_MAX);
-
-	s->serv_fns.connection_accept = service->serv_fns.connection_accept;
-	s->serv_fns.connection_created = service->serv_fns.connection_created;
-	s->serv_fns.msg_process = service->serv_fns.msg_process;
-	s->serv_fns.connection_closed =	service->serv_fns.connection_closed;
-	s->serv_fns.connection_destroyed = s->serv_fns.connection_destroyed;
 	s->alias_for = service;
-
-	qb_list_init(&s->connections);
-	qb_list_init(&s->list);
-	qb_list_add(&s->list, &qb_ipc_services);
 
 	return s;
 }
@@ -153,6 +122,9 @@ qb_ipcs_run(struct qb_ipcs_service *s)
 
 	if (s->alias_for) {
 		memcpy(&s->poll_fns, &s->alias_for->poll_fns, sizeof(s->poll_fns));
+
+		/* Clear this now so we don't use it by accident later when the original connection might have gone away */
+		s->alias_for = NULL;
 	}
 
 	if (s->poll_fns.dispatch_add == NULL ||


### PR DESCRIPTION
This creates a new IPC server destination that is simply an alias for an existing one. The idea (from Ken) is to help provide easy backwards compatibility in a lightweight way.

Posting for discussion at the moment