### PR TITLE
unix(qb_sys_circular_mmap): return -1 when mmap() returns a new addr

### DIFF
--- a/lib/unix.c
+++ b/lib/unix.c
@@ -196,6 +196,9 @@ qb_sys_circular_mmap(int32_t fd, void **buf, size_t bytes)
 #endif
 
 	if (addr != addr_orig) {
+		/* explicitly set errno to non-zero because last mmap()
+		   could succeed and errno can be zero */
+		errno = EINVAL;
 		res = -errno;
 		goto cleanup_fail;
 	}


### PR DESCRIPTION
mmap() succeed when it returns a new address different from original
address. In that case errno remains unchanged and can be zero and,
therefore, cannot be used as a return value, because in this case this
leads to a memory access violation.

Found and reported by Mikhail Kulagin <m.kulagin at postgrespro dot ru>