### PR TITLE
unix.c: use posix_fallocate()

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -259,7 +259,7 @@ AC_FUNC_CHOWN
 AC_FUNC_FORK
 AC_FUNC_MMAP
 AC_FUNC_STRERROR_R
-AC_CHECK_FUNCS([alarm fsync fdatasync ftruncate \
+AC_CHECK_FUNCS([alarm fsync fdatasync ftruncate posix_fallocate \
 		gettimeofday localtime localtime_r \
 		memset munmap socket \
 		strchr strrchr strdup strstr strcasecmp \


### PR DESCRIPTION
Using of posix_fallocate() guarantees that, if it succeed, the
attempting to write to allocated space range does not fail because of
lack of storage space. This prevents SIGBUS when trying to write to
mmaped file and no space left.

Co-Authored-by: Ivan Zakharyaschev <imz@altlinux.org>
Reported-by: Mikhail Kulagin <m.kulagin at postgrespro dot ru>