### PR TITLE
[doxy] fix build when more aggressive -W options are used

### DIFF
--- a/doxygen2man/doxygen2man.c
+++ b/doxygen2man/doxygen2man.c
@@ -409,7 +409,7 @@ static int read_structure_from_xml(const char *refid, const char *name)
 static char *allcaps(const char *name)
 {
 	static char buffer[1024] = {'\0'};
-	int i;
+	size_t i;
 
 	for (i=0; i< strlen(name); i++) {
 		buffer[i] = toupper(name[i]);


### PR DESCRIPTION
make[2]: Entering directory '/builddir/build/BUILD/kronosnet-1.17/man'
gcc -DHAVE_CONFIG_H -I. -I..    -O3 -ggdb3 -Werror -Wall -Wextra -Wno-unused-parameter -pthread  -I/usr/include/libxml2   -c -o doxyxml-doxyxml.o `test -f 'doxyxml.c' || echo './'`doxyxml.c
doxyxml.c: In function 'allcaps':
doxyxml.c:414:13: error: comparison of integer expressions of different signedness: 'int' and 'size_t' {aka 'long unsigned int'} [-Werror=sign-compare]
  414 |  for (i=0; i< strlen(name); i++) {
      |             ^
cc1: all warnings being treated as errors
make[2]: *** [Makefile:623: doxyxml-doxyxml.o] Error 1
make[2]: Leaving directory '/builddir/build/BUILD/kronosnet-1.17/man'
make[1]: *** [Makefile:567: all-recursive] Error 1

Signed-off-by: Fabio M. Di Nitto <fdinitto@redhat.com>