### PR TITLE
log: add qb_log_open2() API call

### DIFF
--- a/include/qb/qblog.h
+++ b/include/qb/qblog.h
@@ -652,6 +652,19 @@ void qb_log_format_set(int32_t t, const char* format);
 int32_t qb_log_file_open(const char *filename);
 
 /**
+ * Open a log file with set permissions
+ *
+ * These permissions are stored with the target and
+ * will also be applied to qb_log_reopen()
+ *
+ * @retval -errno on error
+ * @retval value in inclusive range QB_LOG_TARGET_DYNAMIC_START
+ *         to QB_LOG_TARGET_DYNAMIC_END
+ *         (to be passed into other qb_log_* functions)
+ */
+int32_t qb_log_file_open2(const char *filename, mode_t mode);
+
+/**
  * Close a log file and release its resources.
  */
 void qb_log_file_close(int32_t t);

--- a/lib/log_int.h
+++ b/lib/log_int.h
@@ -43,6 +43,7 @@ struct qb_log_target {
 	size_t size;
 	size_t max_line_length;
 	int32_t ellipsis;
+	mode_t file_mode;
 	char *format;
 	int32_t threaded;
 	void *instance;


### PR DESCRIPTION
Log files are created using the default umask which is not always what's wanted.

It would be neater to have this as a qb_log_ctl2() option but that call needs a handle which we can only get from qb_log_open(), so we need a new API call.