### PR TITLE
doxygen2man: Add option to read copyright line from the header file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -123,6 +123,7 @@ BUILT_SOURCES	= .version
 
 # untaint configure.ac when modified upon obtaining the "yanked" snapshot form
 dist-hook: gen-ChangeLog
+	echo $(SOURCE_EPOCH) > $(distdir)/source_epoch
 	echo $(VERSION) | tee $(distdir)/.tarball-version | grep -Eqv '\-yank' \
 	  || sed "s/\(.*git-version-gen[^']*[']\)[^']*/\1\$$Format:%h??%D\$$/" \
 	     $(distdir)/configure.ac > $(builddir)/configure.ac-t

--- a/build-aux/update-copyright.sh
+++ b/build-aux/update-copyright.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+#
+# Copyright (C) 2017-2019 Red Hat, Inc.  All rights reserved.
+#
+# Author: Fabio M. Di Nitto <fabbione@kronosnet.org>
+#
+# This software licensed under GPL-2.0+
+#
+
+# script to update copyright dates across the tree
+
+enddate=$(date +%Y)
+
+input=$(grep -ril -e "Copyright.*Red Hat" |grep -v .swp |grep -v update-copyright |grep -v doxyxml.c)
+for i in $input; do
+	startdate=$(git log --follow "" | grep ^Date: | tail -n 1 | awk '{print $6}')
+	if [ "$startdate" != "$enddate" ]; then
+		sed -i -e 's#Copyright (C).*Red Hat#Copyright (C) '$startdate'-'$enddate' Red Hat#g' $i
+	else
+		sed -i -e 's#Copyright (C).*Red Hat#Copyright (C) '$startdate' Red Hat#g' $i
+	fi
+done
+
+input=$(find . -type f |grep -v ".git")
+for i in $input; do
+	if [ -z "$(grep -i "Copyright" $i)" ]; then
+		echo "WARNING: $i appears to be missing Copyright information"
+	fi
+done

--- a/configure.ac
+++ b/configure.ac
@@ -803,6 +803,47 @@ AC_DEFINE_UNQUOTED([QB_VER_REST],
 		            -e t -e 's|.*|""|')],
 		   [libqb patch version])
 
+AX_PROG_DATE
+AS_IF([test "$ax_cv_prog_date_gnu_date:$ax_cv_prog_date_gnu_utc" = yes:yes],
+	[UTC_DATE_AT="date -u -d@"],
+	[AS_IF([test "x$ax_cv_prog_date_bsd_date" = xyes],
+		[UTC_DATE_AT="date -u -r"],
+		[AC_MSG_ERROR([date utility unable to convert epoch to UTC])])])
+AC_SUBST([UTC_DATE_AT])
+
+AC_ARG_VAR([SOURCE_EPOCH],[last modification date of the source])
+AC_MSG_NOTICE([trying to determine source epoch])
+AC_MSG_CHECKING([for source epoch in \$SOURCE_EPOCH])
+AS_IF([test -n "$SOURCE_EPOCH"],
+	[AC_MSG_RESULT([yes])],
+	[AC_MSG_RESULT([no])
+	 AC_MSG_CHECKING([for source epoch in source_epoch file])
+	 AS_IF([test -e "$srcdir/source_epoch"],
+		[read SOURCE_EPOCH <"$srcdir/source_epoch"
+		 AC_MSG_RESULT([yes])],
+		[AC_MSG_RESULT([no])
+		 AC_MSG_CHECKING([for source epoch baked in by gitattributes export-subst])
+		 SOURCE_EPOCH='$Format:%ct$' # template for rewriting by git-archive
+		 AS_CASE([$SOURCE_EPOCH],
+			[?Format:*], # was not rewritten
+				[AC_MSG_RESULT([no])
+				 AC_MSG_CHECKING([for source epoch in \$SOURCE_DATE_EPOCH])
+				 AS_IF([test "x$SOURCE_DATE_EPOCH" != x],
+					[SOURCE_EPOCH="$SOURCE_DATE_EPOCH"
+					 AC_MSG_RESULT([yes])],
+					[AC_MSG_RESULT([no])
+					 AC_MSG_CHECKING([whether git log can provide a source epoch])
+					 SOURCE_EPOCH=f${SOURCE_EPOCH#\$F} # convert into git log --pretty format
+					 SOURCE_EPOCH=$(cd "$srcdir" && git log -1 --pretty=${SOURCE_EPOCH%$} 2>/dev/null)
+					 AS_IF([test -n "$SOURCE_EPOCH"],
+						[AC_MSG_RESULT([yes])],
+						[AC_MSG_RESULT([no, using current time and breaking reproducibility])
+						 SOURCE_EPOCH=$(date +%s)])])],
+			[AC_MSG_RESULT([yes])]
+		 )])
+	])
+AC_MSG_NOTICE([using source epoch $($UTC_DATE_AT$SOURCE_EPOCH +'%F %T %Z')])
+
 AC_CONFIG_FILES([Makefile
 		 include/Makefile
 		 include/qb/Makefile

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -25,7 +25,8 @@ dist_man_MANS = man8/qb-blackbox.8
 if HAVE_DOXYGEN
 if BUILD_MAN
 
-doxygen2man_flags = -q -i qb/ -o man3/ -m -g -P -H "libqb Programmer's Manual" -p LIBQB -c -O ../include/qb
+doxygen2man_flags = -q -i qb/ -o man3/ -m -g -P -H "libqb Programmer's Manual" $$($(UTC_DATE_AT)$(SOURCE_EPOCH) +"-D %F -Y %Y") \
+		    -p LIBQB -c -O ../include/qb -Y $(SOURCE_EPOCH)
 
 man3_MANS = \
 	man3/qb_array_create_2.3 \

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -25,7 +25,7 @@ dist_man_MANS = man8/qb-blackbox.8
 if HAVE_DOXYGEN
 if BUILD_MAN
 
-doxygen2man_flags = -q -i qb/ -o man3/ -m -g -P -H "libqb Programmer's Manual" -p LIBQB
+doxygen2man_flags = -q -i qb/ -o man3/ -m -g -P -H "libqb Programmer's Manual" -p LIBQB -c -O ../include/qb
 
 man3_MANS = \
 	man3/qb_array_create_2.3 \

--- a/doxygen2man/doxygen2man.1
+++ b/doxygen2man/doxygen2man.1
@@ -6,7 +6,7 @@
 .\" * Author: Christine Caulfield <ccaulfie@redhat.com>
 .\" *
 
-.TH "DOXYGEN2MAN" "8" "2020-03-09" "" ""
+.TH "DOXYGEN2MAN" "8" "2020-09-09" "" ""
 .SH "NAME"
 doxygen2man \- A tool to generate man pages from Doxygen XML files
 .SH "SYNOPSIS"
@@ -68,6 +68,17 @@ Write all man pages to <dir> (default .)
 .TP
 .B -d <dir>
 Directory for XML files (./xml/)
+.TP
+.B -c
+Use the Copyright line from the header file as the copyright line in the manpage. 
+This requires that doxygen2man has access to the original .h file (see option -O below)
+and that the Copyright line has a defined format. It whould be within the first 10 lines
+of the file and start with the text " * Copyright". If this line is not found then 
+the current year or that given by the -Y option will be used.
+.TP
+.B -O
+Specifies the directory containing the original header files. This is (currently) only
+used by the -c option above.
 .TP
 .B -h
 Print usage text

--- a/include/qb/qbarray.h
+++ b/include/qb/qbarray.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Red Hat, Inc.
+ * Copyright (C) 2010-2020 Red Hat, Inc.
  *
  * Author: Angus Salkeld <asalkeld@redhat.com>
  *

--- a/include/qb/qbconfig.h.in
+++ b/include/qb/qbconfig.h.in
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011 Red Hat, Inc.
+ * Copyright (C) 2010-2020 Red Hat, Inc.
  *
  * All rights reserved.
  *

--- a/include/qb/qbdefs.h
+++ b/include/qb/qbdefs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Red Hat, Inc.
+ * Copyright (C) 2010-2020 Red Hat, Inc.
  *
  * Author: Angus Salkeld <asalkeld@redhat.com>
  *

--- a/include/qb/qbhdb.h
+++ b/include/qb/qbhdb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2010 Red Hat, Inc.
+ * Copyright (C) 2010-2020 Red Hat, Inc.
  *
  * Author: Steven Dake <sdake@redhat.com>
  *

--- a/include/qb/qbipcc.h
+++ b/include/qb/qbipcc.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2007, 2009 Red Hat, Inc.
+ * Copyright (C) 2010-2020 Red Hat, Inc.
  *
  * Author: Steven Dake <sdake@redhat.com>
  *

--- a/include/qb/qbipcs.h
+++ b/include/qb/qbipcs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2009 Red Hat, Inc.
+ * Copyright (C) 2010-2020 Red Hat, Inc.
  *
  * Author: Steven Dake <sdake@redhat.com>,
  *         Angus Salkeld <asalkeld@redhat.com>

--- a/include/qb/qblist.h
+++ b/include/qb/qblist.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2006-2010, 2009 Red Hat, Inc.
+ * Copyright (C) 2010-2020 Red Hat, Inc.
  *
  * Author: Steven Dake <sdake@redhat.com>
  *

--- a/include/qb/qbloop.h
+++ b/include/qb/qbloop.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Red Hat, Inc.
+ * Copyright (C) 2010-2020 Red Hat, Inc.
  *
  * Author: Angus Salkeld <asalkeld@redhat.com>
  *

--- a/include/qb/qbmap.h
+++ b/include/qb/qbmap.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2011 Red Hat, Inc.
+ * Copyright (C) 2010-2020 Red Hat, Inc.
  *
  * Author: Angus Salkeld <asalkeld@redhat.com>
  *

--- a/include/qb/qbrb.h
+++ b/include/qb/qbrb.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Red Hat, Inc.
+ * Copyright (C) 2010-2020 Red Hat, Inc.
  *
  * Author: Angus Salkeld <asalkeld@redhat.com>
  *

--- a/include/qb/qbutil.h
+++ b/include/qb/qbutil.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Red Hat, Inc.
+ * Copyright (C) 2010-2020 Red Hat, Inc.
  *
  * Author: Angus Salkeld <asalkeld@redhat.com>
  *

--- a/m4/ax_prog_date.m4
+++ b/m4/ax_prog_date.m4
@@ -1,0 +1,137 @@
+# ===========================================================================
+#       https://www.gnu.org/software/autoconf-archive/ax_prog_date.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PROG_DATE()
+#
+# DESCRIPTION
+#
+#   This macro tries to determine the type of the date (1) command and some
+#   of its non-standard capabilities.
+#
+#   The type is determined as follow:
+#
+#     * If the version string contains "GNU", then:
+#       - The variable ax_cv_prog_date_gnu is set to "yes".
+#       - The variable ax_cv_prog_date_type is set to "gnu".
+#
+#     * If date supports the "-v 1d" option, then:
+#       - The variable ax_cv_prog_date_bsd is set to "yes".
+#       - The variable ax_cv_prog_date_type is set to "bsd".
+#
+#     * If both previous checks fail, then:
+#       - The variable ax_cv_prog_date_type is set to "unknown".
+#
+#   The following capabilities of GNU date are checked:
+#
+#     * If date supports the --date arg option, then:
+#       - The variable ax_cv_prog_date_gnu_date is set to "yes".
+#
+#     * If date supports the --utc arg option, then:
+#       - The variable ax_cv_prog_date_gnu_utc is set to "yes".
+#
+#   The following capabilities of BSD date are checked:
+#
+#     * If date supports the -v 1d  option, then:
+#       - The variable ax_cv_prog_date_bsd_adjust is set to "yes".
+#
+#     * If date supports the -r arg option, then:
+#       - The variable ax_cv_prog_date_bsd_date is set to "yes".
+#
+#   All the aforementioned variables are set to "no" before a check is
+#   performed.
+#
+# LICENSE
+#
+#   Copyright (c) 2017 Enrico M. Crisostomo <enrico.m.crisostomo@gmail.com>
+#
+#   This program is free software: you can redistribute it and/or modify it
+#   under the terms of the GNU General Public License as published by the
+#   Free Software Foundation, either version 3 of the License, or (at your
+#   option) any later version.
+#
+#   This program is distributed in the hope that it will be useful, but
+#   WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General
+#   Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License along
+#   with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#   As a special exception, the respective Autoconf Macro's copyright owner
+#   gives unlimited permission to copy, distribute and modify the configure
+#   scripts that are the output of Autoconf when processing the Macro. You
+#   need not follow the terms of the GNU General Public License when using
+#   or distributing such scripts, even though portions of the text of the
+#   Macro appear in them. The GNU General Public License (GPL) does govern
+#   all other use of the material that constitutes the Autoconf Macro.
+#
+#   This special exception to the GPL applies to versions of the Autoconf
+#   Macro released by the Autoconf Archive. When you make and distribute a
+#   modified version of the Autoconf Macro, you may extend this special
+#   exception to the GPL to apply to your modified version as well.
+
+#serial 3
+
+AC_DEFUN([AX_PROG_DATE], [dnl
+  AC_CACHE_CHECK([for GNU date], [ax_cv_prog_date_gnu], [
+    ax_cv_prog_date_gnu=no
+    if date --version 2>/dev/null | head -1 | grep -q GNU
+    then
+      ax_cv_prog_date_gnu=yes
+    fi
+  ])
+  AC_CACHE_CHECK([for BSD date], [ax_cv_prog_date_bsd], [
+    ax_cv_prog_date_bsd=no
+    if date -v 1d > /dev/null 2>&1
+    then
+      ax_cv_prog_date_bsd=yes
+    fi
+  ])
+  AC_CACHE_CHECK([for date type], [ax_cv_prog_date_type], [
+    ax_cv_prog_date_type=unknown
+    if test "x${ax_cv_prog_date_gnu}" = "xyes"
+    then
+      ax_cv_prog_date_type=gnu
+    elif test "x${ax_cv_prog_date_bsd}" = "xyes"
+    then
+      ax_cv_prog_date_type=bsd
+    fi
+  ])
+  AS_VAR_IF([ax_cv_prog_date_gnu], [yes], [
+    AC_CACHE_CHECK([whether GNU date supports --date], [ax_cv_prog_date_gnu_date], [
+      ax_cv_prog_date_gnu_date=no
+      if date --date=@1512031231 > /dev/null 2>&1
+      then
+        ax_cv_prog_date_gnu_date=yes
+      fi
+    ])
+    AC_CACHE_CHECK([whether GNU date supports --utc], [ax_cv_prog_date_gnu_utc], [
+      ax_cv_prog_date_gnu_utc=no
+      if date --utc > /dev/null 2>&1
+      then
+        ax_cv_prog_date_gnu_utc=yes
+      fi
+    ])
+  ])
+  AS_VAR_IF([ax_cv_prog_date_bsd], [yes], [
+    AC_CACHE_CHECK([whether BSD date supports -r], [ax_cv_prog_date_bsd_date], [
+      ax_cv_prog_date_bsd_date=no
+      if date -r 1512031231 > /dev/null 2>&1
+      then
+        ax_cv_prog_date_bsd_date=yes
+      fi
+    ])
+  ])
+    AS_VAR_IF([ax_cv_prog_date_bsd], [yes], [
+    AC_CACHE_CHECK([whether BSD date supports -v], [ax_cv_prog_date_bsd_adjust], [
+      ax_cv_prog_date_bsd_adjust=no
+      if date -v 1d > /dev/null 2>&1
+      then
+        ax_cv_prog_date_bsd_adjust=yes
+      fi
+    ])
+  ])
+])dnl AX_PROG_DATE


### PR DESCRIPTION
This should help make builds reproducible.

I tried various methods of getting the date, using 'git' is no use as
it could be run from a tarball, using the file date doesn't work either
so this seems a reasonable compromise.