### PR TITLE
ipc: add qb_ipcc_auth_get() API call

### DIFF
--- a/include/qb/qbipcc.h
+++ b/include/qb/qbipcc.h
@@ -110,6 +110,17 @@ void qb_ipcc_disconnect(qb_ipcc_connection_t* c);
 int32_t qb_ipcc_fd_get(qb_ipcc_connection_t* c, int32_t * fd);
 
 /**
+ * Get the credentials of the server process
+ *
+ *
+ * @param c connection instance
+ * @param pid PID of the server we are connected to
+ * @param uid UID of the server we are connected to
+ * @param gid GID of the server we are connected to
+ */
+int32_t qb_ipcc_auth_get(qb_ipcc_connection_t* c, pid_t *pid, uid_t *uid, gid_t *gid);
+
+/**
  * Set the maximum allowable flowcontrol value.
  *
  * @note the default is 1

--- a/lib/ipc_int.h
+++ b/lib/ipc_int.h
@@ -92,7 +92,6 @@ struct qb_ipcc_connection {
 	char name[NAME_MAX];
 	int32_t needs_sock_for_poll;
 	gid_t egid;
-	uid_t euid;
 	pid_t server_pid;
 	struct qb_ipc_one_way setup;
 	struct qb_ipc_one_way request;
@@ -103,6 +102,7 @@ struct qb_ipcc_connection {
 	uint32_t fc_enable_max;
 	int32_t is_connected;
 	void * context;
+	uid_t euid;
 };
 
 int32_t qb_ipcc_us_setup_connect(struct qb_ipcc_connection *c,

--- a/lib/ipc_int.h
+++ b/lib/ipc_int.h
@@ -92,6 +92,7 @@ struct qb_ipcc_connection {
 	char name[NAME_MAX];
 	int32_t needs_sock_for_poll;
 	gid_t egid;
+	uid_t euid;
 	pid_t server_pid;
 	struct qb_ipc_one_way setup;
 	struct qb_ipc_one_way request;

--- a/lib/ipc_setup.c
+++ b/lib/ipc_setup.c
@@ -494,6 +494,7 @@ qb_ipcc_us_setup_connect(struct qb_ipcc_connection *c,
 
 	qb_ipc_auth_creds(data);
 	c->egid = data->ugp.gid;
+	c->euid = data->ugp.uid;
 	c->server_pid = data->ugp.pid;
 
 	destroy_ipc_auth_data(data);

--- a/lib/ipcc.c
+++ b/lib/ipcc.c
@@ -366,6 +366,18 @@ qb_ipcc_fd_get(struct qb_ipcc_connection * c, int32_t * fd)
 	return 0;
 }
 
+int32_t
+qb_ipcc_auth_get(struct qb_ipcc_connection * c, pid_t *pid, uid_t *uid, gid_t *gid)
+{
+	if (c == NULL || pid == NULL || uid == NULL || gid == NULL) {
+		return -EINVAL;
+	}
+	*pid = c->server_pid;
+	*uid = c->euid;
+	*gid = c->egid;
+	return 0;
+}
+
 ssize_t
 qb_ipcc_event_recv(struct qb_ipcc_connection * c, void *msg_pt,
 		   size_t msg_len, int32_t ms_timeout)

--- a/lib/ipcc.c
+++ b/lib/ipcc.c
@@ -369,12 +369,18 @@ qb_ipcc_fd_get(struct qb_ipcc_connection * c, int32_t * fd)
 int32_t
 qb_ipcc_auth_get(struct qb_ipcc_connection * c, pid_t *pid, uid_t *uid, gid_t *gid)
 {
-	if (c == NULL || pid == NULL || uid == NULL || gid == NULL) {
+	if (c == NULL) {
 		return -EINVAL;
 	}
-	*pid = c->server_pid;
-	*uid = c->euid;
-	*gid = c->egid;
+	if (pid) {
+		*pid = c->server_pid;
+	}
+	if (uid) {
+		*uid = c->euid;
+	}
+	if (gid) {
+		*gid = c->egid;
+	}
 	return 0;
 }
 

--- a/lib/unix.c
+++ b/lib/unix.c
@@ -74,10 +74,12 @@ qb_sys_mmap_file_open(char *path, const char *file, size_t bytes,
 		       uint32_t file_flags)
 {
 	int32_t fd;
-	int32_t i;
 	int32_t res = 0;
+#ifndef HAVE_POSIX_FALLOCATE
 	ssize_t written;
 	char *buffer = NULL;
+	int32_t i;
+#endif
 	char *is_absolute = strchr(file, '/');
 
 	if (is_absolute) {


### PR DESCRIPTION
We can't use SO_PEERCRED on the client fd when using socket IPC
becayse it's a DGRAM socket (pacemaker tries this). So provide
an API to get the server credentials that libqb has already
squirreled away for its own purposes.

Also, fix some unused-variable compiler warnings in unix.c
when building on systems withpout posix_fallocate().