### PR TITLE
doc related fixups

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,4 +1,3 @@
 man3
-html
 xml
 *.dox

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -256,4 +256,4 @@ endif
 endif
 
 clean-local:
-	rm -rf html man3 xml
+	rm -rf man3 xml

--- a/docs/man.dox.in
+++ b/docs/man.dox.in
@@ -1221,14 +1221,14 @@ GENERATE_BUGLIST       = NO
 # that contain example code fragments that are included (see the \include
 # command).
 
-#EXAMPLE_PATH           =
+EXAMPLE_PATH           = ../examples
 
 # If the value of the EXAMPLE_PATH tag contains directories, you can use the
 # EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and
 # *.h) to filter out the source-files in the directories. If left blank all
 # files are included.
 
-#EXAMPLE_PATTERNS       =
+EXAMPLE_PATTERNS       = *.c
 
 # If the EXAMPLE_RECURSIVE tag is set to YES then subdirectories will be
 # searched for input files to be used with the \include or \dontinclude commands

--- a/doxygen2man/doxygen2man.1
+++ b/doxygen2man/doxygen2man.1
@@ -6,7 +6,7 @@
 .\" * Author: Christine Caulfield <ccaulfie@redhat.com>
 .\" *
 
-.TH "DOXYGEN2MAN" "8" "2020-09-09" "" ""
+.TH "DOXYGEN2MAN" "1" "2020-09-09" "" ""
 .SH "NAME"
 doxygen2man \- A tool to generate man pages from Doxygen XML files
 .SH "SYNOPSIS"

--- a/include/qb/qbrb.h
+++ b/include/qb/qbrb.h
@@ -268,7 +268,7 @@ ssize_t qb_rb_chunks_used(qb_ringbuffer_t * rb);
 ssize_t qb_rb_write_to_file(qb_ringbuffer_t * rb, int32_t fd);
 
 /**
- * Load the saved ring buffer from file into tempory memory.
+ * Load the saved ring buffer from file into temporary memory.
  * @param fd file with saved ringbuffer data.
  * @param flags same flags as passed into qb_rb_open()
  * @return new ringbuffer instance


### PR DESCRIPTION
The changes in `docs/man.dox.in` silenced some "file not found" warnings, but I didn't check the actual output (the resulting `qbipcc.h.3` has no real content with 2.0.1, but maybe I looked in the wrong way).
The removal of the `http` directory is entirely untested for now, but wanted to share the idea anyway.