### PR TITLE
ipcs : Decrease log level.

### DIFF
--- a/lib/ipcs.c
+++ b/lib/ipcs.c
@@ -406,7 +406,7 @@ qb_ipcs_event_send(struct qb_ipcs_connection * c, const void *data, size_t size)
 		resn = new_event_notification(c);
 		if (resn < 0 && resn != -EAGAIN && resn != -ENOBUFS) {
 			errno = -resn;
-			qb_util_perror(LOG_WARNING,
+			qb_util_perror(LOG_DEBUG,
 				       "new_event_notification (%s)",
 				       c->description);
 			res = resn;
@@ -448,7 +448,7 @@ qb_ipcs_event_sendv(struct qb_ipcs_connection * c,
 		resn = new_event_notification(c);
 		if (resn < 0 && resn != -EAGAIN) {
 			errno = -resn;
-			qb_util_perror(LOG_WARNING,
+			qb_util_perror(LOG_DEBUG,
 				       "new_event_notification (%s)",
 				       c->description);
 			res = resn;


### PR DESCRIPTION
Hi All,

In the environment where libqb and Pacemaker are combined, in rare cases, a "Broken pipe" error occurs in new_event_notification () when stopped.

The phenomenon is reported and discussed in the following Pacemaker Bugzilla.
 - https://bugs.clusterlabs.org/show_bug.cgi?id=5457
 - https://bugs.clusterlabs.org/show_bug.cgi?id=5445 

This error can confuse the user.
Is it possible to lower the log level of libqb to debug?

In the future, if this error occurs, Pacemaker will consider changing to a log output that is a little easier to understand.

Best Regards,
Hideo Yamauchi.
