### PR TITLE
doxygen2man: ignore all-whitespace brief descriptions

### DIFF
--- a/doxygen2man/doxygen2man.c
+++ b/doxygen2man/doxygen2man.c
@@ -756,7 +756,7 @@ static void print_manpage(char *name, char *def, char *brief, char *args, char *
 	fprintf(manfile, ".TH %s %s %s \"%s\" \"%s\"\n", allcaps(name), man_section, dateptr, package_name, header);
 
 	fprintf(manfile, ".SH NAME\n");
-	if (brief) {
+	if (brief && not_all_whitespace(brief)) {
 		fprintf(manfile, "%s \\- %s\n", name, brief);
 	} else {
 		fprintf(manfile, "%s\n", name);


### PR DESCRIPTION
Brief descriptions are an important component of man pages, so I'm not sure this is wanted, but `qb_atomic_init`, `qb_hdb_base_convert`, `qb_hdb_nocheck_convert`, `qb_log_from_external_source_va`, `qb_log_real_va_`, `qb_loop_destroy` and `qb_util_stopwatch_split_ctl` currently lack one.