### PR TITLE
Add a message-id parameter for messages

### DIFF
--- a/lib/log.c
+++ b/lib/log.c
@@ -317,7 +317,8 @@ qb_log_thread_log_write(struct qb_log_callsite *cs,
 }
 
 struct qb_log_callsite*
-qb_log_callsite_get(const char *function,
+qb_log_callsite_get2(const char *message_id,
+		    const char *function,
 		    const char *filename,
 		    const char *format,
 		    uint8_t priority,
@@ -335,8 +336,9 @@ qb_log_callsite_get(const char *function,
 		return NULL;
 	}
 
-	cs = qb_log_dcs_get(&new_dcs, function, filename,
-			    format, priority, lineno, tags);
+	cs = qb_log_dcs_get(&new_dcs, message_id, function, filename,
+ 			    format, priority, lineno, tags);
+
 	if (cs == NULL) {
 		return NULL;
 	}
@@ -380,8 +382,21 @@ qb_log_callsite_get(const char *function,
 	return cs;
 }
 
+struct qb_log_callsite*
+qb_log_callsite_get(const char *function,
+		    const char *filename,
+		    const char *format,
+		    uint8_t priority,
+		    uint32_t lineno,
+		    uint32_t tags)
+{
+	return qb_log_callsite_get2(NULL, function, filename, format,
+				    priority, lineno, tags);
+}
+
 void
-qb_log_from_external_source_va(const char *function,
+qb_log_from_external_source_va2(const char *message_id,
+			       const char *function,
 			       const char *filename,
 			       const char *format,
 			       uint8_t priority,
@@ -393,9 +408,20 @@ qb_log_from_external_source_va(const char *function,
 		return;
 	}
 
-	cs = qb_log_callsite_get(function, filename,
+	cs = qb_log_callsite_get2(message_id, function, filename,
 				 format, priority, lineno, tags);
 	qb_log_real_va_(cs, ap);
+}
+
+void
+qb_log_from_external_source_va(const char *function,
+			       const char *filename,
+			       const char *format,
+			       uint8_t priority,
+			       uint32_t lineno, uint32_t tags, va_list ap)
+{
+	qb_log_from_external_source_va2(NULL, function, filename,
+				   format, priority, lineno, tags, ap);
 }
 
 void

--- a/lib/log_int.h
+++ b/lib/log_int.h
@@ -125,6 +125,7 @@ void qb_log_thread_resume(struct qb_log_target *t);
 void qb_log_dcs_init(void);
 void qb_log_dcs_fini(void);
 struct qb_log_callsite *qb_log_dcs_get(int32_t *newly_created,
+				       const char *message_id,
 				       const char *function,
 				       const char *filename,
 				       const char *format,

--- a/lib/log_syslog.c
+++ b/lib/log_syslog.c
@@ -64,13 +64,24 @@ _syslog_logger(int32_t target,
 	}
 #ifdef USE_JOURNAL
 	if (t->use_journal) {
-		sd_journal_send("PRIORITY=%d", final_priority,
+		if (cs->message_id) {
+			sd_journal_send("MESSAGE_ID=%s", cs->message_id,
+				"PRIORITY=%d", final_priority,
 				"CODE_LINE=%d", cs->lineno,
 				"CODE_FILE=%s", cs->filename,
 				"CODE_FUNC=%s", cs->function,
 				"SYSLOG_IDENTIFIER=%s", t->name,
 				"MESSAGE=%s", output_buffer,
 				NULL);
+		} else {
+			sd_journal_send("PRIORITY=%d", final_priority,
+				"CODE_LINE=%d", cs->lineno,
+				"CODE_FILE=%s", cs->filename,
+				"CODE_FUNC=%s", cs->function,
+				"SYSLOG_IDENTIFIER=%s", t->name,
+				"MESSAGE=%s", output_buffer,
+				NULL);
+		}
 	} else {
 #endif
 		syslog(final_priority, "%s", output_buffer);

--- a/tests/check_log.c
+++ b/tests/check_log.c
@@ -1021,12 +1021,13 @@ START_TEST(test_journal)
 	pid_t log_pid;
 	sd_journal *jnl;
 	int count = 0;
+	const char *msgid="f77379a8490b408bbe5f6940505a777b";
 
 	qb_log_init("check_log", LOG_USER, LOG_DEBUG);
 	qb_log_ctl(QB_LOG_SYSLOG, QB_LOG_CONF_ENABLED, QB_TRUE);
 	rc = qb_log_ctl(QB_LOG_SYSLOG, QB_LOG_CONF_USE_JOURNAL, 1);
 	ck_assert_int_eq(rc, 0);
-	qb_log(LOG_ERR, "Test message 1 from libqb");
+	qb_log2(msgid, LOG_ERR, "Test message 1 from libqb");
 
 	qb_log_ctl(QB_LOG_BLACKBOX, QB_LOG_CONF_ENABLED, QB_TRUE);
 	rc = qb_log_ctl(QB_LOG_BLACKBOX, QB_LOG_CONF_USE_JOURNAL, 1);
@@ -1046,6 +1047,9 @@ START_TEST(test_journal)
 	    if (log_pid == getpid()) {
 	        rc = sd_journal_get_data(jnl, "MESSAGE", (const void **)&msg, &len);
 		ck_assert_int_eq(rc, 0);
+	        rc = sd_journal_get_data(jnl, "MESSAGE_ID", (const void **)&msg, &len);
+		ck_assert_int_eq(rc, 0);
+		ck_assert_str_eq(msg+11, msgid);
 		break;
 	    }
 	    if (++count > 20) {


### PR DESCRIPTION
DON'T MERGE

The message-ids are used by systemd catalogs. (see https://github.com/ClusterLabs/sbd/pull/117)

To enable this feature the libqb should be configured with the
` --enable-systemd-journal` option.

IMPORTANT:

The libqb exposes the
```
struct qb_log_callsite
qb_log_callsite_get(...
qb_log_from_external_source_va(..
```
To make it completely backward compatible, they all three should come with
and without the `message_id` parameter. This would however require repeating a
good half of the libqb. We did only a half-measure: we provided the
`qb_log_from_external_source_va2`
to make it working with the corosync. It's not however backward compatible with the pacemaker.

@beekhof , @jfriesse , @jnpkrn , please give your feedback. (The PR done in the continuation of the conversation started here https://github.com/ClusterLabs/sbd/pull/117  thought a bit later than planned). It's mostly interesting if it should be backward compatible and if so, then how to make it.