### PR TITLE
Implement heap based timer list

### DIFF
--- a/lib/loop_timerlist.c
+++ b/lib/loop_timerlist.c
@@ -115,6 +115,8 @@ qb_loop_timer_destroy(struct qb_loop *l)
 {
 	struct qb_timer_source *my_src =
 	    (struct qb_timer_source *)l->timer_source;
+
+	timerlist_destroy(&my_src->timerlist);
 	qb_array_free(my_src->timers);
 	free(l->timer_source);
 }

--- a/lib/loop_timerlist.c
+++ b/lib/loop_timerlist.c
@@ -76,7 +76,9 @@ expire_the_timers(struct qb_loop_source *s, int32_t ms_timeout)
 {
 	struct qb_timer_source *ts = (struct qb_timer_source *)s;
 	expired_timers = 0;
-	timerlist_expire(&ts->timerlist);
+	if (timerlist_expire(&ts->timerlist) != 0) {
+		qb_util_log(LOG_ERR, "timerlist_expire failed");
+	}
 	return expired_timers;
 }
 
@@ -265,7 +267,9 @@ qb_loop_timer_del(struct qb_loop * lp, qb_loop_timer_handle th)
 	}
 
 	if (t->timerlist_handle) {
-		timerlist_del(&s->timerlist, t->timerlist_handle);
+		if (timerlist_del(&s->timerlist, t->timerlist_handle) != 0) {
+			qb_util_log(LOG_ERR, "Could not delete timer from timerlist");
+		}
 	}
 	t->state = QB_POLL_ENTRY_EMPTY;
 	return 0;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -124,7 +124,7 @@ resources.log: rb.log log.log ipc.log
 
 check_LTLIBRARIES =
 check_PROGRAMS = array.test ipc.test list.test log.test loop.test \
-		 map.test rb.test util.test \
+		 map.test rb.test util.test tlist.test \
 		 crash_test_dummy file_change_bytes
 dist_check_SCRIPTS = start.test resources.test blackbox-segfault.sh
 
@@ -160,6 +160,10 @@ rb_test_LDADD = $(top_builddir)/lib/libqb.la @CHECK_LIBS@
 loop_test_SOURCES = check_loop.c
 loop_test_CFLAGS = @CHECK_CFLAGS@
 loop_test_LDADD = $(top_builddir)/lib/libqb.la @CHECK_LIBS@
+
+tlist_test_SOURCES = check_tlist.c
+tlist_test_CFLAGS = @CHECK_CFLAGS@
+tlist_test_LDADD = $(top_builddir)/lib/libqb.la @CHECK_LIBS@
 
 ipc_test_SOURCES = check_ipc.c
 ipc_test_CFLAGS = @CHECK_CFLAGS@

--- a/tests/check_loop.c
+++ b/tests/check_loop.c
@@ -448,7 +448,7 @@ static void *loop_timer_thread(void *arg)
 	res = qb_loop_timer_add(l, QB_LOOP_LOW, 5*QB_TIME_NS_IN_MSEC, l, one_shot_tmo, &test_tht);
 	ck_assert_int_eq(res, 0);
 
-	res = qb_loop_timer_is_running(l, test_th);
+	res = qb_loop_timer_is_running(l, test_tht);
 	ck_assert_int_eq(res, QB_TRUE);
 
 	sleep(5);

--- a/tests/check_tlist.c
+++ b/tests/check_tlist.c
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2021 Red Hat, Inc.
+ *
+ * All rights reserved.
+ *
+ * Author: Jan Friesse <jfriesse@redhat.com>
+ *
+ * This file is part of libqb.
+ *
+ * libqb is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2.1 of the License, or
+ * (at your option) any later version.
+ *
+ * libqb is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with libqb.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "os_base.h"
+
+#include "check_common.h"
+
+#include "tlist.h"
+
+#include <poll.h>
+
+#include <qb/qbdefs.h>
+#include <qb/qbutil.h>
+#include <qb/qblog.h>
+
+#define SHORT_TIMEOUT		(100 * QB_TIME_NS_IN_MSEC)
+#define LONG_TIMEOUT		(60 * QB_TIME_NS_IN_SEC)
+
+#define SPEED_TEST_NO_ITEMS	10000
+
+static int timer_list_fn1_called = 0;
+
+static void
+timer_list_fn1(void *data)
+{
+
+	ck_assert(data == &timer_list_fn1_called);
+
+	timer_list_fn1_called++;
+}
+
+static void
+sleep_ns(long long int ns)
+{
+
+	(void)poll(NULL, 0, (ns / QB_TIME_NS_IN_MSEC));
+}
+
+START_TEST(test_check_basic)
+{
+	struct timerlist tlist;
+	timer_handle thandle;
+	int res;
+	uint64_t u64;
+
+	timerlist_init(&tlist);
+
+	/*
+	 * Check adding short duration and calling callback
+	 */
+	res = timerlist_add_duration(&tlist, timer_list_fn1, &timer_list_fn1_called, SHORT_TIMEOUT / 2, &thandle);
+	ck_assert_int_eq(res, 0);
+
+	sleep_ns(SHORT_TIMEOUT);
+	u64 = timerlist_msec_duration_to_expire(&tlist);
+	ck_assert(u64 == 0);
+
+	timer_list_fn1_called = 0;
+	timerlist_expire(&tlist);
+	ck_assert_int_eq(timer_list_fn1_called, 1);
+
+	u64 = timerlist_msec_duration_to_expire(&tlist);
+	ck_assert(u64 == -1);
+
+	/*
+	 * Check callback is not called (long timeout)
+	 */
+	res = timerlist_add_duration(&tlist, timer_list_fn1, &timer_list_fn1_called, LONG_TIMEOUT / 2, &thandle);
+	ck_assert_int_eq(res, 0);
+
+	sleep_ns(SHORT_TIMEOUT);
+	u64 = timerlist_msec_duration_to_expire(&tlist);
+	ck_assert(u64 > 0);
+
+	timer_list_fn1_called = 0;
+	timerlist_expire(&tlist);
+	ck_assert_int_eq(timer_list_fn1_called, 0);
+
+	u64 = timerlist_msec_duration_to_expire(&tlist);
+	ck_assert(u64 > 0);
+
+	/*
+	 * Delete timer
+	 */
+	timerlist_del(&tlist, thandle);
+	u64 = timerlist_msec_duration_to_expire(&tlist);
+	ck_assert(u64 == -1);
+}
+END_TEST
+
+START_TEST(test_check_speed)
+{
+	struct timerlist tlist;
+	timer_handle thandle[SPEED_TEST_NO_ITEMS];
+	int res;
+	uint64_t u64;
+	int i;
+
+	timerlist_init(&tlist);
+
+	/*
+	 * Check adding a lot of short duration and deleting
+	 */
+	for (i = 0; i < SPEED_TEST_NO_ITEMS; i++) {
+		res = timerlist_add_duration(&tlist, timer_list_fn1, &timer_list_fn1_called,
+		    SHORT_TIMEOUT / 2, &thandle[i]);
+		ck_assert_int_eq(res, 0);
+	}
+
+	for (i = 0; i < SPEED_TEST_NO_ITEMS; i++) {
+		timerlist_del(&tlist, thandle[i]);
+	}
+
+	u64 = timerlist_msec_duration_to_expire(&tlist);
+	ck_assert(u64 == -1);
+
+	/*
+	 * Check adding a lot of short duration and calling callback
+	 */
+	for (i = 0; i < SPEED_TEST_NO_ITEMS; i++) {
+		res = timerlist_add_duration(&tlist, timer_list_fn1, &timer_list_fn1_called,
+		    SHORT_TIMEOUT / 2, &thandle[i]);
+		ck_assert_int_eq(res, 0);
+	}
+
+	u64 = timerlist_msec_duration_to_expire(&tlist);
+	ck_assert(u64 != -1);
+
+	sleep_ns(SHORT_TIMEOUT);
+
+	timer_list_fn1_called = 0;
+	timerlist_expire(&tlist);
+	ck_assert_int_eq(timer_list_fn1_called, SPEED_TEST_NO_ITEMS);
+
+	u64 = timerlist_msec_duration_to_expire(&tlist);
+	ck_assert(u64 == -1);
+}
+END_TEST
+
+static Suite *tlist_suite(void)
+{
+	TCase *tc;
+	Suite *s = suite_create("tlist");
+
+	add_tcase(s, tc, test_check_basic);
+	add_tcase(s, tc, test_check_speed, 30);
+
+	return s;
+}
+
+int32_t main(void)
+{
+	int32_t number_failed;
+
+	Suite *s = tlist_suite();
+	SRunner *sr = srunner_create(s);
+
+	qb_log_init("check", LOG_USER, LOG_EMERG);
+	atexit(qb_log_fini);
+	qb_log_ctl(QB_LOG_SYSLOG, QB_LOG_CONF_ENABLED, QB_FALSE);
+	qb_log_filter_ctl(QB_LOG_STDERR, QB_LOG_FILTER_ADD,
+			  QB_LOG_FILTER_FILE, "*", LOG_INFO);
+	qb_log_ctl(QB_LOG_STDERR, QB_LOG_CONF_ENABLED, QB_TRUE);
+
+	srunner_run_all(sr, CK_VERBOSE);
+	number_failed = srunner_ntests_failed(sr);
+	srunner_free(sr);
+	return (number_failed == 0) ? EXIT_SUCCESS : EXIT_FAILURE;
+}


### PR DESCRIPTION
Previous timer was sorted list implementation of priority queue and very slow when number of timers increased. This is mostly not a problem because usually only few timers are used.  But for application where bigger number of timers are needed it may become problem.    

Solution is to use binary heap based priority queue which is much faster.
   
API is unchanged, just timerlist_destroy is added which should be called to free heap array. This function also destroys mutex (omitted when mutex was added).

It's worth noting that qb loop timer is using qb array which is (by default right now) limited to 65 536 entries and it is doing its own mapping of tlist entries and searching by simple for cycle (so lineary) so speed improvement here is really not big for real app.

I've used `check_tlist.c`to measure improvement:
- SPEED_TEST_NO_ITEMS set to 40 000
Previous implementation:
```
Running suite(s): tlist
100%: Checks: 2, Failures: 0, Errors: 0
check_tlist.c:107:P:check_basic:test_check_basic:0: Passed
check_tlist.c:156:P:check_speed:test_check_speed:0: Passed

real	0m15.323s
user	0m14.692s
sys	0m0.270s
```
New implementation:
```
Running suite(s): tlist
100%: Checks: 2, Failures: 0, Errors: 0
check_tlist.c:113:P:check_basic:test_check_basic:0: Passed
check_tlist.c:164:P:check_speed:test_check_speed:0: Passed

real	0m0.761s
user	0m0.229s
sys	0m0.233s
```

For default (10000) speedup is not really that impressive:
Original:
```
real	0m1.253s
user	0m0.857s
sys	0m0.095s
```
Patched:
```
real	0m0.459s
user	0m0.079s
sys	0m0.085s
```

No matter what, I believe the extra code is worth - if not, then test suite for sure is ;)
