### PR TITLE
build: Fix undefined pthread reference.

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -38,7 +38,8 @@ bmc_SOURCES = bmc.c
 bmc_LDADD = $(top_builddir)/lib/libqb.la
 
 bmcpt_SOURCES = bmcpt.c
-bmcpt_LDADD = $(top_builddir)/lib/libqb.la
+bmcpt_CFLAGS = $(PTHREAD_CFLAGS)
+bmcpt_LDADD = $(PTHREAD_LIBS) $(top_builddir)/lib/libqb.la
 
 bms_SOURCES = bms.c
 bms_CFLAGS = $(GLIB_CFLAGS)


### PR DESCRIPTION
When using slibtool (https://github.com/midipix-project/slibtool) instead of GNU libtool the build fails with undefined references to pthread.
```
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: bmcpt.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: /lib64/libpthread.so.0: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```
This works with GNU libtool because it silently filters out `-no-undefined` while slibtool does not.

This can be easily fixed by added `$(PTHREAD_CFLAGS)` and `$(PTHREAD_LIBS)` where applicable.

Also see this downstream issue: https://bugs.gentoo.org/775605