### PR TITLE
poll: Don't log in a signal handler

### DIFF
--- a/lib/loop_poll.c
+++ b/lib/loop_poll.c
@@ -475,12 +475,8 @@ try_again:
 		res = write(pipe_fds[1], &sig, sizeof(int32_t));
 		if (res == -1 && errno == EAGAIN) {
 			goto try_again;
-		} else if (res != sizeof(int32_t)) {
-			qb_util_log(LOG_ERR,
-				    "failed to write signal to pipe [%d]", res);
 		}
 	}
-	qb_util_log(LOG_TRACE, "got real signal [%d] sent to pipe", sig);
 }
 
 static void


### PR DESCRIPTION
qb_log calls malloc() and probably many other non-signal-safe
functions, so don't call it in the signal handler.

Thanks to Honza for spotting this

Signed-off-by: Christine Caulfield <ccaulfie@redhat.com>