### PR TITLE
tests: Run IPC with use-filesystem-sockets active

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -176,7 +176,7 @@ PKG_CHECK_MODULES([libxml], [libxml-2.0])
 # don´t build the man pages
 if test "x$cross_compiling" = "xno"; then
   AM_CONDITIONAL([BUILD_MAN], [true])
-  DOXYGEN2MAN="\"\$(abs_builddir)/../doxygen2man/doxygen2man\""
+  DOXYGEN2MAN="\$(abs_builddir)/../doxygen2man/doxygen2man"
 else
   AC_CHECK_PROGS([DOXYGEN2MAN], [doxygen2man])
   if test "x$DOXYGEN2MAN" = "x"; then

--- a/configure.ac
+++ b/configure.ac
@@ -176,7 +176,7 @@ PKG_CHECK_MODULES([libxml], [libxml-2.0])
 # don´t build the man pages
 if test "x$cross_compiling" = "xno"; then
   AM_CONDITIONAL([BUILD_MAN], [true])
-  DOXYGEN2MAN="\$(abs_builddir)/../doxygen2man/doxygen2man"
+  DOXYGEN2MAN="\"\$(abs_builddir)/../doxygen2man/doxygen2man\""
 else
   AC_CHECK_PROGS([DOXYGEN2MAN], [doxygen2man])
   if test "x$DOXYGEN2MAN" = "x"; then

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -236,19 +236,19 @@ txt-man: man.dox
 
 xml-man: txt-man
 	mkdir -p man3
-	$(DOXYGEN2MAN) $(doxygen2man_flags) qbarray_8h.xml
-	$(DOXYGEN2MAN) $(doxygen2man_flags) qbatomic_8h.xml
-	$(DOXYGEN2MAN) $(doxygen2man_flags) qbdefs_8h.xml
-	$(DOXYGEN2MAN) $(doxygen2man_flags) qbhdb_8h.xml
-	$(DOXYGEN2MAN) $(doxygen2man_flags) qbipcc_8h.xml
-	$(DOXYGEN2MAN) $(doxygen2man_flags) qbipc__common_8h.xml
-	$(DOXYGEN2MAN) $(doxygen2man_flags) qbipcs_8h.xml
-	$(DOXYGEN2MAN) $(doxygen2man_flags) qblist_8h.xml
-	$(DOXYGEN2MAN) $(doxygen2man_flags) qblog_8h.xml
-	$(DOXYGEN2MAN) $(doxygen2man_flags) qbloop_8h.xml
-	$(DOXYGEN2MAN) $(doxygen2man_flags) qbmap_8h.xml
-	$(DOXYGEN2MAN) $(doxygen2man_flags) qbrb_8h.xml
-	$(DOXYGEN2MAN) $(doxygen2man_flags) qbutil_8h.xml
+	"$(DOXYGEN2MAN)" $(doxygen2man_flags) qbarray_8h.xml
+	"$(DOXYGEN2MAN)" $(doxygen2man_flags) qbatomic_8h.xml
+	"$(DOXYGEN2MAN)" $(doxygen2man_flags) qbdefs_8h.xml
+	"$(DOXYGEN2MAN)" $(doxygen2man_flags) qbhdb_8h.xml
+	"$(DOXYGEN2MAN)" $(doxygen2man_flags) qbipcc_8h.xml
+	"$(DOXYGEN2MAN)" $(doxygen2man_flags) qbipc__common_8h.xml
+	"$(DOXYGEN2MAN)" $(doxygen2man_flags) qbipcs_8h.xml
+	"$(DOXYGEN2MAN)" $(doxygen2man_flags) qblist_8h.xml
+	"$(DOXYGEN2MAN)" $(doxygen2man_flags) qblog_8h.xml
+	"$(DOXYGEN2MAN)" $(doxygen2man_flags) qbloop_8h.xml
+	"$(DOXYGEN2MAN)" $(doxygen2man_flags) qbmap_8h.xml
+	"$(DOXYGEN2MAN)" $(doxygen2man_flags) qbrb_8h.xml
+	"$(DOXYGEN2MAN)" $(doxygen2man_flags) qbutil_8h.xml
 
 all: $(man3_MANS) xml-man
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -114,11 +114,16 @@ endif
 bench_log_SOURCES = bench-log.c
 bench_log_LDADD = $(top_builddir)/lib/libqb.la
 
+lib_LTLIBRARIES = libstat_wrapper.la
+libstat_wrapper_la_SOURCES = libstat_wrapper.c
+libstat_wrapper_la_LIBADD = -ldl
+libdir= $(TESTDIR)
+
 if HAVE_CHECK
-EXTRA_DIST += start.test resources.test
+EXTRA_DIST += start.test resources.test ipc_sock.test
 EXTRA_DIST += blackbox-segfault.sh
 
-TESTS = start.test array.test map.test rb.test list.test log.test blackbox-segfault.sh loop.test ipc.test resources.test
+TESTS = start.test array.test map.test rb.test list.test log.test blackbox-segfault.sh loop.test ipc.test ipc_sock.test resources.test
 TESTS_ENVIRONMENT = export PATH=.:../tools:$$PATH;
 
 resources.log: rb.log log.log ipc.log
@@ -127,7 +132,7 @@ check_LTLIBRARIES =
 check_PROGRAMS = array.test ipc.test list.test log.test loop.test \
 		 map.test rb.test util.test tlist.test \
 		 crash_test_dummy file_change_bytes
-dist_check_SCRIPTS = start.test resources.test blackbox-segfault.sh
+dist_check_SCRIPTS = start.test resources.test blackbox-segfault.sh ipc_sock.test
 
 if HAVE_SLOW_TESTS
 TESTS += util.test

--- a/tests/ipc_sock.test
+++ b/tests/ipc_sock.test
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+# Run the IPC tests under the stat wrapper,
+# this simulates /etc/libqb/use-filesystem-sockets existing
+# so we can test both options without breaking other things
+# that might be running on this system
+#
+if [ "`uname -s`" = "Linux" ]
+then
+  if [ -f `pwd`/.libs/libstatwrapper.so ]
+  then
+    export LD_PRELOAD=`pwd`/.libs/libstat_wrapper.so
+  else
+    export LD_PRELOAD=`pwd`/libstat_wrapper.so
+  fi
+  ./ipc.test
+else
+  exit 0
+fi

--- a/tests/ipc_sock.test
+++ b/tests/ipc_sock.test
@@ -7,11 +7,11 @@
 #
 if [ "$(uname -s)" = "Linux" ]
 then
-  if [ -f $(pwd)/.libs/libstat_wrapper.so ]
+  if [ -f "$(pwd)/.libs/libstat_wrapper.so" ]
   then
-    export LD_PRELOAD=$(pwd)/.libs/libstat_wrapper.so
+    export "LD_PRELOAD=$(pwd)/.libs/libstat_wrapper.so"
   else
-    export LD_PRELOAD=$(pwd)/libstat_wrapper.so
+    export "LD_PRELOAD=$(pwd)/libstat_wrapper.so"
   fi
   ./ipc.test
 else

--- a/tests/ipc_sock.test
+++ b/tests/ipc_sock.test
@@ -5,13 +5,13 @@
 # so we can test both options without breaking other things
 # that might be running on this system
 #
-if [ "`uname -s`" = "Linux" ]
+if [ "$(uname -s)" = "Linux" ]
 then
-  if [ -f `pwd`/.libs/libstat_wrapper.so ]
+  if [ -f $(pwd)/.libs/libstat_wrapper.so ]
   then
-    export LD_PRELOAD=`pwd`/.libs/libstat_wrapper.so
+    export LD_PRELOAD=$(pwd)/.libs/libstat_wrapper.so
   else
-    export LD_PRELOAD=`pwd`/libstat_wrapper.so
+    export LD_PRELOAD=$(pwd)/libstat_wrapper.so
   fi
   ./ipc.test
 else

--- a/tests/ipc_sock.test
+++ b/tests/ipc_sock.test
@@ -7,7 +7,7 @@
 #
 if [ "`uname -s`" = "Linux" ]
 then
-  if [ -f `pwd`/.libs/libstatwrapper.so ]
+  if [ -f `pwd`/.libs/libstat_wrapper.so ]
   then
     export LD_PRELOAD=`pwd`/.libs/libstat_wrapper.so
   else

--- a/tests/libstat_wrapper.c
+++ b/tests/libstat_wrapper.c
@@ -1,0 +1,35 @@
+/*
+ * Simulate FORCESOCKETSFILE existing for the IPC tests
+ */
+
+#include <stdio.h>
+#include <dlfcn.h>
+#include <string.h>
+#include <sys/stat.h>
+#include "../include/config.h"
+#if defined(QB_LINUX) || defined(QB_CYGWIN)
+#include <gnu/lib-names.h>
+#endif
+
+int __xstat(int __ver, const char *__filename, struct stat *__stat_buf)
+{
+#if defined(QB_LINUX) || defined(QB_CYGWIN)
+	static int opened = 0;
+	static void *dlhandle;
+	static int (*real_xstat)(int __ver, const char *__filename, void *__stat_buf);
+
+	if (!opened) {
+		dlhandle = dlopen(LIBC_SO, RTLD_NOW);
+		real_xstat = dlsym(dlhandle, "__xstat");
+		opened = 1;
+	}
+
+	if (strcmp(__filename, FORCESOCKETSFILE) == 0) {
+		return 0; /* it exists! */
+	}
+
+	return real_xstat(__ver, __filename, __stat_buf);
+#else
+	return -1; /* Error in the unlikely event we get called on *BSD* */
+#endif
+}

--- a/tests/libstat_wrapper.c
+++ b/tests/libstat_wrapper.c
@@ -1,7 +1,7 @@
 /*
  * Simulate FORCESOCKETSFILE existing for the IPC tests
  */
-
+#define _GNU_SOURCE
 #include <stdio.h>
 #include <dlfcn.h>
 #include <string.h>
@@ -11,17 +11,15 @@
 #include <gnu/lib-names.h>
 #endif
 
-// __xstat for ealier libc
+// __xstat for earlier libc
 int __xstat(int __ver, const char *__filename, struct stat *__stat_buf)
 {
 #if defined(QB_LINUX) || defined(QB_CYGWIN)
 	static int opened = 0;
-	static void *dlhandle;
 	static int (*real_xstat)(int __ver, const char *__filename, void *__stat_buf);
 
 	if (!opened) {
-		dlhandle = dlopen(LIBC_SO, RTLD_NOW);
-		real_xstat = dlsym(dlhandle, "__xstat");
+		real_xstat = dlsym(RTLD_NEXT, "__xstat");
 		opened = 1;
 	}
 
@@ -36,17 +34,15 @@ int __xstat(int __ver, const char *__filename, struct stat *__stat_buf)
 #endif
 }
 
-// Stat for F35 and later
+// stat for F35 and later
 int stat(const char *__filename, struct stat *__stat_buf)
 {
 #if defined(QB_LINUX) || defined(QB_CYGWIN)
 	static int opened = 0;
-	static void *dlhandle;
 	static int (*real_stat)(const char *__filename, void *__stat_buf);
 
 	if (!opened) {
-		dlhandle = dlopen(LIBC_SO, RTLD_NOW);
-		real_stat = dlsym(dlhandle, "stat");
+		real_stat = dlsym(RTLD_NEXT, "stat");
 		opened = 1;
 	}
 

--- a/tests/libstat_wrapper.c
+++ b/tests/libstat_wrapper.c
@@ -11,6 +11,7 @@
 #include <gnu/lib-names.h>
 #endif
 
+// __xstat for ealier libc
 int __xstat(int __ver, const char *__filename, struct stat *__stat_buf)
 {
 #if defined(QB_LINUX) || defined(QB_CYGWIN)
@@ -25,10 +26,36 @@ int __xstat(int __ver, const char *__filename, struct stat *__stat_buf)
 	}
 
 	if (strcmp(__filename, FORCESOCKETSFILE) == 0) {
+		fprintf(stderr, "__xstat called for %s\n", __filename);
 		return 0; /* it exists! */
 	}
 
 	return real_xstat(__ver, __filename, __stat_buf);
+#else
+	return -1; /* Error in the unlikely event we get called on *BSD* */
+#endif
+}
+
+// Stat for F35 and later
+int stat(const char *__filename, struct stat *__stat_buf)
+{
+#if defined(QB_LINUX) || defined(QB_CYGWIN)
+	static int opened = 0;
+	static void *dlhandle;
+	static int (*real_stat)(const char *__filename, void *__stat_buf);
+
+	if (!opened) {
+		dlhandle = dlopen(LIBC_SO, RTLD_NOW);
+		real_stat = dlsym(dlhandle, "stat");
+		opened = 1;
+	}
+
+	if (strcmp(__filename, FORCESOCKETSFILE) == 0) {
+		fprintf(stderr, "stat called for %s\n", __filename);
+		return 0; /* it exists! */
+	}
+
+	return real_stat(__filename, __stat_buf);
 #else
 	return -1; /* Error in the unlikely event we get called on *BSD* */
 #endif

--- a/tests/resources.test
+++ b/tests/resources.test
@@ -1,23 +1,33 @@
 #!/bin/sh
 RETURN=0
 SOCKS_PER_PROCESS=3
+EXPECTED_DLOCK=6
+EXPECTED_LEFTOVER=2
+
+# Linux also runs filesystem socket tests
+if [ "$(uname -s)" = "Linux" ]
+then
+    EXPECTED_DLOCK=12
+    EXPECTED_LEFTOVER=4
+fi
 
 tidy_qb_dirs()
 {
     for dd in "$@"; do
 	rm $dd
-	rmdir `dirname $dd` 2> /dev/null
+	rmdir $(dirname $dd) 2> /dev/null
     done
 }
 
 
-IPC_NAME=`cat ipc-test-name 2>/dev/null`
+IPC_NAME=$(cat ipc-test-name 2>/dev/null)
 for d in /dev/shm /var/run $SOCKETDIR; do
 
 	# Tidy up the deadlock checker sockets first
 	dlocks=$(find $d -name "qb-*-test_*dlock*${IPC_NAME}*" -size +0c 2>/dev/null)
-	if [ "`echo $dlocks|wc -w`" -eq $(($SOCKS_PER_PROCESS * 6)) ]; then
-	    tidy_qb_dirs $dlocks
+	if [ "$(echo $dlocks|wc -w)" -eq $(($SOCKS_PER_PROCESS * $EXPECTED_DLOCK)) ]; then
+	        tidy_qb_dirs $dlocks
+	        rm $dlocks
 	elif [ -n "${dlocks}" ]; then
 		echo
 		echo "Error: dlock shared memory segments not closed/unlinked"
@@ -34,7 +44,7 @@ for d in /dev/shm /var/run $SOCKETDIR; do
 		RETURN=1
 	fi
 	leftovers="$(find $d -name "qb-*-test_*${IPC_NAME}*" -size 0c 2>/dev/null)"
-	if [ "$(printf '%s\n' "${leftovers}" | wc -l)" -eq $(($SOCKS_PER_PROCESS * 2)) ]; then
+	if [ "$(printf '%s\n' "${leftovers}" | wc -l)" -eq $(($SOCKS_PER_PROCESS * $EXPECTED_LEFTOVER)) ]; then
 		echo
 		echo "There were some empty leftovers (expected), removing them"
 		echo "${leftovers}"

--- a/tests/start.test
+++ b/tests/start.test
@@ -7,7 +7,7 @@
 # The test programs all add "qb-test-<name>-" to the front of this.
 #
 
-NAME="$$-`date +%s`"
+NAME="$$-$(date +%s)"
 
 printf "$NAME" > ipc-test-name
 mkdir -p $SOCKETDIR


### PR DESCRIPTION
(re-opening PR 380 that got lost in the Great Git Transition of 2021)

Provide an LD_PRELOAD library that simulates the presence
of /etc/libqb/use-filesystem-sockets so that we can test
that functionality without actually having the file on
the system and affecting everything else running on the
box.