### PR TITLE
test: Clean /dev/shm a bit better

### DIFF
--- a/tests/check_ipc.c
+++ b/tests/check_ipc.c
@@ -1509,7 +1509,7 @@ count_stress_events(int32_t fd, int32_t revents, void *data)
 			qb_log(LOG_DEBUG, "RECV: %d stress events processed", events_received);
 			if (res != sizeof(giant_event_recv)) {
 				qb_log(LOG_DEBUG, "Unexpected recv size, expected %d got %d",
-					res, sizeof(giant_event_recv));
+				       sizeof(giant_event_recv), res);
 
 				ck_assert_int_eq(res, sizeof(giant_event_recv));
 			} else if (giant_event_recv.sent_msgs != events_received) {

--- a/tests/resources.test
+++ b/tests/resources.test
@@ -2,16 +2,22 @@
 RETURN=0
 SOCKS_PER_PROCESS=3
 
+tidy_qb_dirs()
+{
+    for dd in "$@"; do
+	rm $dd
+	rmdir `dirname $dd` 2> /dev/null
+    done
+}
+
+
 IPC_NAME=`cat ipc-test-name 2>/dev/null`
 for d in /dev/shm /var/run $SOCKETDIR; do
 
 	# Tidy up the deadlock checker sockets first
 	dlocks=$(find $d -name "qb-*-test_*dlock*${IPC_NAME}*" -size +0c 2>/dev/null)
 	if [ "`echo $dlocks|wc -w`" -eq $(($SOCKS_PER_PROCESS * 6)) ]; then
-	        for dd in $dlocks; do
-		    rm $dd
-		    rmdir `dirname $dd` 2> /dev/null
-		done
+	    tidy_qb_dirs $dlocks
 	elif [ -n "${dlocks}" ]; then
 		echo
 		echo "Error: dlock shared memory segments not closed/unlinked"
@@ -31,12 +37,9 @@ for d in /dev/shm /var/run $SOCKETDIR; do
 	if [ "$(printf '%s\n' "${leftovers}" | wc -l)" -eq $(($SOCKS_PER_PROCESS * 2)) ]; then
 		echo
 		echo "There were some empty leftovers (expected), removing them"
-		echo "${leftovers}" | tee /dev/stderr
+		echo "${leftovers}"
 		echo
-		for dd in $leftovers; do
-		    rm $dd
-		    rmdir `dirname $dd` 2>/dev/null
-		done
+		tidy_qb_dirs $leftovers
 	elif [ -n "${leftovers}" ]; then
 		echo
 		echo "Error: unexpected number of empty leftovers"

--- a/tests/resources.test
+++ b/tests/resources.test
@@ -8,7 +8,10 @@ for d in /dev/shm /var/run $SOCKETDIR; do
 	# Tidy up the deadlock checker sockets first
 	dlocks=$(find $d -name "qb-*-test_*dlock*${IPC_NAME}*" -size +0c 2>/dev/null)
 	if [ "`echo $dlocks|wc -w`" -eq $(($SOCKS_PER_PROCESS * 6)) ]; then
-		rm $dlocks
+	        for dd in $dlocks; do
+		    rm $dd
+		    rmdir `dirname $dd` 2> /dev/null
+		done
 	elif [ -n "${dlocks}" ]; then
 		echo
 		echo "Error: dlock shared memory segments not closed/unlinked"
@@ -16,7 +19,7 @@ for d in /dev/shm /var/run $SOCKETDIR; do
 		RETURN=1
 	fi
 
-	# Now look for other leftovers
+	# Now look for other expected leftovers
 	leftovers=$(find $d -name "qb-*-test_*${IPC_NAME}*" -size +0c 2>/dev/null | wc -l)
 	if [ "${leftovers}" -gt 0 ]; then
 		echo
@@ -28,8 +31,12 @@ for d in /dev/shm /var/run $SOCKETDIR; do
 	if [ "$(printf '%s\n' "${leftovers}" | wc -l)" -eq $(($SOCKS_PER_PROCESS * 2)) ]; then
 		echo
 		echo "There were some empty leftovers (expected), removing them"
-		echo "${leftovers}" | tee /dev/stderr | xargs rm
+		echo "${leftovers}" | tee /dev/stderr
 		echo
+		for dd in $leftovers; do
+		    rm $dd
+		    rmdir `dirname $dd` 2>/dev/null
+		done
 	elif [ -n "${leftovers}" ]; then
 		echo
 		echo "Error: unexpected number of empty leftovers"


### PR DESCRIPTION
This isn't perfect, but it does tidy more of /dev/shm than
previously. Because some of the tests leave empty directories
we have no way of telling (in resources.test) whether they
belong to this test run, another test run, or a running
application.