### PR TITLE
ipcc: Fix errno returned from qb_ipcc_connect

### DIFF
--- a/lib/ipcc.c
+++ b/lib/ipcc.c
@@ -152,7 +152,7 @@ disconnect_and_cleanup:
 	free(c->receive_buf);
 	free(c);
 	errno = -res;
-	return -res;
+	return res;
 
 }
 


### PR DESCRIPTION
The errno value from qb_ipcc_connect was incorrectly negated
when I introduced qb_ipcc_async_connect()