### PR TITLE
unix: Don't fail on FreeBSD running ZFS

### DIFF
--- a/lib/unix.c
+++ b/lib/unix.c
@@ -132,6 +132,11 @@ qb_sys_mmap_file_open(char *path, const char *file, size_t bytes,
 		if (res == EINTR) {
 			qb_util_log(LOG_DEBUG, "got EINTR trying to allocate file %s, retrying...", path);
 			continue;
+#ifdef QB_BSD
+		} else if (res == EINVAL) { /* posix_fallocate() fails on ZFS
+					       https://lists.freebsd.org/pipermail/freebsd-current/2018-February/068448.html */
+			qb_util_log(LOG_DEBUG, "posix_fallocate returned EINVAL - running on ZFS?");
+#endif
 		} else if (res != 0) {
 			errno = res;
 			res = -1 * res;

--- a/tests/check_ipc.c
+++ b/tests/check_ipc.c
@@ -1959,8 +1959,8 @@ test_ipc_disconnect_after_created(void)
 		ck_assert_int_eq(res, -ENOTCONN);
 	}
 	ck_assert_int_eq(QB_FALSE, qb_ipcc_is_connected(conn));
-
 	qb_ipcc_disconnect(conn);
+	sleep(1); /* Give it time to stop */
 	kill_server(pid);
 }
 


### PR DESCRIPTION
ZFS doesn't support posix_fallocate() so libqb IPC or RB would
always fail with EINVAL.

As there seems to be no prospect of a more useful return code,
trap it in a QB_BSD #ifdef. That way if we do have actual errors
in the posix_fallocate() call the Linux tests should still find them.

Also, stick a small sleep in the test_ipc_disconnect_after_created
test to allow the server to shutdown before killing it with SIGTERM
and causing a test failure. all the other uses of it seem to have this
sleep!