### PR TITLE
tests: Make ipc test more portable

### DIFF
--- a/tests/ipc_sock.test
+++ b/tests/ipc_sock.test
@@ -7,7 +7,7 @@
 #
 # This creates sockets in /var/run so needs to be root
 #
-if [ "$(uname -s)" = "Linux" -a "$UID" = "0" ]
+if [ "$(uname -s)" = "Linux" ] && [ "`id -u`" = "0" ]
 then
   if [ -f "$(pwd)/.libs/libstat_wrapper.so" ]
   then

--- a/tests/resources.test
+++ b/tests/resources.test
@@ -5,7 +5,7 @@ EXPECTED_DLOCK=6
 EXPECTED_LEFTOVER=2
 
 # Linux also runs filesystem socket tests
-if [ "$(uname -s)" = "Linux" -a "$UID" = "0" ]
+if [ "$(uname -s)" = "Linux" ] && [ "`id -u`" = "0" ]
 then
     EXPECTED_DLOCK=12
     EXPECTED_LEFTOVER=4


### PR DESCRIPTION
fix a couple of errors reported by covscan

1. /usr/lib64/libqb/tests/resources.test:8:34: warning[SC2039]: In POSIX sh, UID is undefined.
1. /usr/lib64/libqb/tests/resources.test:8:30: warning[SC2166]: Prefer [ p ] && [ q ] as [ p -a q ] is not well defined.
1. /usr/lib64/libqb/tests/ipc_sock.test:10:34: warning[SC2039]: In POSIX sh, UID is undefined.
1. /usr/lib64/libqb/tests/ipc_sock.test:10:30: warning[SC2166]: Prefer [ p ] && [ q ] as [ p -a q ] is not well defined.