### PR TITLE
tests: clean up the last of the empty directories

### DIFF
--- a/tests/check_ipc.c
+++ b/tests/check_ipc.c
@@ -1598,15 +1598,18 @@ test_ipc_stress_connections(void)
 	}
 	multiple_connections = QB_FALSE;
 
-	request_server_exit();
-	verify_graceful_stop(pid);
-	qb_ipcc_disconnect(conn);
-
+	/* Re-enable logging here so we get the "Free'ing" message which allows
+	   for resources.test to clear up after us if needed */
 	qb_log_filter_ctl(QB_LOG_STDERR, QB_LOG_FILTER_CLEAR_ALL,
 			  QB_LOG_FILTER_FILE, "*", LOG_TRACE);
 	qb_log_filter_ctl(QB_LOG_STDERR, QB_LOG_FILTER_ADD,
 			  QB_LOG_FILTER_FILE, "*", LOG_TRACE);
 	qb_log_ctl(QB_LOG_STDERR, QB_LOG_CONF_ENABLED, QB_TRUE);
+
+	request_server_exit();
+	qb_ipcc_disconnect(conn);
+	verify_graceful_stop(pid);
+
 }
 
 static void

--- a/tests/resources.test
+++ b/tests/resources.test
@@ -58,6 +58,15 @@ for d in /dev/shm /var/run $SOCKETDIR; do
 		RETURN=1
 	fi
 done
+
+# Clean up empty /dev/shm directories left over by some tests
+DIRS=$(grep "Free'ing ringbuffer" ipc.log ipc_sock.log| cut -f4 -d ' '|cut -f-4 -d'/'|sort|uniq)
+for i in $DIRS
+do
+    rmdir $i 2>/dev/null
+done
+
+
 ps aux | grep -v grep | grep -E 'lt-.*\.test'
 if [ $? -eq 0 ]; then
 	echo "test program frozen"


### PR DESCRIPTION
This should, FINALLY, allow the libqb tests to run
and properly clean up up after themselves.