### PR TITLE
strlcpy: avoid compiler warning from strncpy

### DIFF
--- a/lib/strlcpy.c
+++ b/lib/strlcpy.c
@@ -31,14 +31,11 @@ size_t
 strlcpy(char *dest, const char * src, size_t maxlen)
 {
 	size_t	srclen = strlen(src);
-	size_t	len2cpy = QB_MIN(maxlen-1, srclen);
 
-	/* check maxlen separately as it could have underflowed from 0 above. */
 	if (maxlen) {
-		if (len2cpy > 0) {
-			strncpy(dest, src, len2cpy+1);
-		}
-		/* Always terminate, even if its empty */
+		size_t len2cpy = QB_MIN(maxlen-1, srclen);
+
+		memcpy(dest, src, len2cpy);
 		dest[len2cpy] = '\0';
 	}
 	return srclen;


### PR DESCRIPTION
Otherwise GCC complains about ‘__builtin_strncpy’ specified bound
depends on the length of the source argument.

Signed-off-by: Ferenc Wágner <wferi@debian.org>