### PR TITLE
Add --disable-tests option

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -39,7 +39,11 @@ ACLOCAL_AMFLAGS		= -I m4
 
 dist_doc_DATA		= COPYING INSTALL README.markdown
 
-SUBDIRS			= include lib doxygen2man docs tools tests examples
+SUBDIRS			= include lib doxygen2man docs tools examples
+
+if ENABLE_TESTS
+SUBDIRS			+= tests
+endif
 
 dist-clean-local:
 	rm -f .snapshot-version autoconf automake autoheader

--- a/configure.ac
+++ b/configure.ac
@@ -562,6 +562,11 @@ AC_ARG_WITH([force-sockets-config-file],
 	[ FORCESOCKETSFILE="$withval" ],
 	[ FORCESOCKETSFILE="$sysconfdir/libqb/force-filesystem-sockets" ])
 
+AC_ARG_ENABLE([tests],
+  [AS_HELP_STRING([--disable-tests],[disable tests])],,
+  [ enable_tests="yes" ])
+AM_CONDITIONAL([ENABLE_TESTS], [test x$enable_tests = xyes])
+
 AC_ARG_ENABLE([install-tests],
   [AS_HELP_STRING([--enable-install-tests],[install tests])],,
   [ enable_install_tests="no" ])


### PR DESCRIPTION
Add `--disable-tests` to allow the user to disable tests. As a side-effect, this will avoid the following build failure when check is found:

```
libstat_wrapper.c:11:10: fatal error: gnu/lib-names.h: No such file or directory
   11 | #include <gnu/lib-names.h>
      |          ^~~~~~~~~~~~~~~~~
```

This build failure is raised since version 2.0.5 and https://github.com/ClusterLabs/libqb/commit/78df90b180740712d0c90b6d982b78241cc99d72

Fixes:
 - http://autobuild.buildroot.org/results/450cfc36d4fd6dc71c138bec45f05b5a2d92a08d

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>