### PR TITLE
timer: Move state check to before time check

### DIFF
--- a/lib/loop_timerlist.c
+++ b/lib/loop_timerlist.c
@@ -326,10 +326,11 @@ qb_loop_timer_expire_time_remaining(struct qb_loop * lp, qb_loop_timer_handle th
 	if (res != 0) {
 		return 0;
 	}
+	if (t->state != QB_POLL_ENTRY_ACTIVE) {
+		return 0;
+	}
 
 	struct timerlist_timer *timer = (struct timerlist_timer *)t->timerlist_handle;
-
-
 	if (timer->is_absolute_timer) {
 		current_ns = qb_util_nano_from_epoch_get();
 	}
@@ -337,12 +338,6 @@ qb_loop_timer_expire_time_remaining(struct qb_loop * lp, qb_loop_timer_handle th
 		current_ns = qb_util_nano_current_get();
 	}
 	uint64_t timer_ns = timerlist_expire_time(&s->timerlist, t->timerlist_handle);
-	/* since time estimation is racy by nature, I'll try to check the state late,
-	 * and try to understand that no matter what, the timer might have expired in the mean time
-	 */
-	if (t->state != QB_POLL_ENTRY_ACTIVE) {
-		return 0;
-	}
 	if (timer_ns < current_ns) {
 		return 0; // respect the "expired" contract
 	}

--- a/tests/check_loop.c
+++ b/tests/check_loop.c
@@ -425,10 +425,10 @@ START_TEST(test_loop_timer_basic)
 	res = qb_loop_timer_add(l, QB_LOOP_LOW, 7*QB_TIME_NS_IN_MSEC, l, reset_one_shot_tmo, &reset_th);
 	ck_assert_int_eq(res, 0);
 
-	res = qb_loop_timer_add(l, QB_LOOP_HIGH, 20*QB_TIME_NS_IN_MSEC, l, check_time_left, &test_th2);
+	res = qb_loop_timer_add(l, QB_LOOP_HIGH, 50*QB_TIME_NS_IN_MSEC, l, check_time_left, &test_th2);
 	ck_assert_int_eq(res, 0);
 
-	res = qb_loop_timer_add(l, QB_LOOP_LOW, 60*QB_TIME_NS_IN_MSEC, l, job_stop, &test_th);
+	res = qb_loop_timer_add(l, QB_LOOP_LOW, 100*QB_TIME_NS_IN_MSEC, l, job_stop, &test_th);
 	ck_assert_int_eq(res, 0);
 
 	qb_loop_run(l);


### PR DESCRIPTION
A timer in QB_POLL_ENTRY_JOBLIST doesn't necessarily have a t->timerlist_handle so that deref can segv. Also the comment assumes the timers are threaded - which as we have decided is definitely not true. So it's safe to move the check earlier.

In the tests, I've adjusted the timeouts so that they definitely happen at different times. On some architectures they can fire concurrently and in the wrong order.