### PR TITLE
test: Remove gnu/lib-names.h from libstat_wrapper.c

### DIFF
--- a/tests/libstat_wrapper.c
+++ b/tests/libstat_wrapper.c
@@ -7,9 +7,6 @@
 #include <string.h>
 #include <sys/stat.h>
 #include "../include/config.h"
-#if defined(QB_LINUX) || defined(QB_CYGWIN)
-#include <gnu/lib-names.h>
-#endif
 
 // __xstat for earlier libc
 int __xstat(int __ver, const char *__filename, struct stat *__stat_buf)


### PR DESCRIPTION
It doesn't appear to be needed.