### PR TITLE
blackbox: fix potential overlow/memory corruption

### DIFF
--- a/lib/log_blackbox.c
+++ b/lib/log_blackbox.c
@@ -118,7 +118,6 @@ _blackbox_vlogger(int32_t target,
 	    msg_len = qb_vsnprintf_serialize(chunk, QB_LOG_MAX_LEN,
 		"Log message too long to be stored in the blackbox.  "\
 		"Maximum is QB_LOG_MAX_LEN" , ap);
-	    actual_size += msg_len;
 	}
 
 	actual_size += msg_len;

--- a/lib/unix.c
+++ b/lib/unix.c
@@ -273,17 +273,18 @@ qb_sys_circular_mmap(int32_t fd, void **buf, size_t bytes)
 
 	res = close(fd);
 	if (res) {
-		goto cleanup_fail;
+		goto cleanup_fail_noclose;
 	}
 	*buf = addr_orig;
 	return 0;
 
 cleanup_fail:
+	close(fd);
 
+cleanup_fail_noclose:
 	if (addr_orig) {
 		munmap(addr_orig, bytes << 1);
 	}
-	close(fd);
 	return res;
 }
 


### PR DESCRIPTION
if the message was too long, then msg_len was added to the buffer size twice, thus causing potential data corruption (seen VERY rarely in the CI test - or, at least, I think it was this).

Also fix a double close() spotted by gcc13's -fanalyzer