### PR TITLE
log: fix potential overflow with long log messages

### DIFF
--- a/lib/log_blackbox.c
+++ b/lib/log_blackbox.c
@@ -110,8 +110,8 @@ _blackbox_vlogger(int32_t target,
 	chunk += sizeof(uint32_t);
 
 	/* log message */
-	msg_len = qb_vsnprintf_serialize(chunk, max_size, cs->format, ap);
-	if (msg_len >= max_size) {
+	msg_len = qb_vsnprintf_serialize(chunk, t->max_line_length, cs->format, ap);
+	if (msg_len >= t->max_line_length) {
 	    chunk = msg_len_pt + sizeof(uint32_t); /* Reset */
 
 	    /* Leave this at QB_LOG_MAX_LEN so as not to overflow the blackbox */

--- a/tests/check_log.c
+++ b/tests/check_log.c
@@ -832,8 +832,10 @@ START_TEST(test_log_long_msg)
 		qb_log(LOG_INFO, "Message %d %d - %s", lpc, lpc%600, buffer);
 	}
 
-        qb_log_blackbox_write_to_file("blackbox.dump");
-        qb_log_blackbox_print_from_file("blackbox.dump");
+        rc = qb_log_blackbox_write_to_file("blackbox.dump");
+	ck_assert_int_gt(rc, 0);
+        rc = qb_log_blackbox_print_from_file("blackbox.dump");
+	ck_assert_int_le(rc, 0);
 	unlink("blackbox.dump");
 	qb_log_fini();
 }


### PR DESCRIPTION
qb_vsnprintf_serialize was called with 'max_size' as the limiting number for the length of the formatted log message. But the buffer also needs to contain the
log header (given by 'actual_size'), so we now pass 'max_size - actual_size' as the maximum length of the formatted log message.

Also added error checks to the blacbkbox calls at
the end of the test, as these now provide a proper test that the BB is functioning. Before they were
masking failures.