### PR TITLE
doxygen2man: Include libxml/parser.h

### DIFF
--- a/doxygen2man/doxygen2man.c
+++ b/doxygen2man/doxygen2man.c
@@ -31,6 +31,7 @@
 #include <errno.h>
 #include <ctype.h>
 #include <libxml/tree.h>
+#include <libxml/parser.h>
 #include <qb/qblist.h>
 #include <qb/qbmap.h>
 #include "cstring.h"


### PR DESCRIPTION
This seems to be needed for newer versions of libxml but shouldn't break older ones (CI to confirm!)