### PR TITLE
Make some logs less noisy

### DIFF
--- a/lib/ipc_setup.c
+++ b/lib/ipc_setup.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010,2013 Red Hat, Inc.
+ * Copyright 2010-2024 Red Hat, Inc.
  *
  * Author: Angus Salkeld <asalkeld@redhat.com>
  *
@@ -765,16 +765,15 @@ send_response:
 		qb_ipcs_connection_unref(c);
 	} else {
 		if (res == -EACCES) {
-			qb_util_log(LOG_ERR, "Invalid IPC credentials (%s).",
+			qb_util_log(LOG_INFO, "IPC connection credentials rejected (%s)",
 				    c->description);
 		} else if (res == -EAGAIN) {
-			qb_util_log(LOG_WARNING, "Denied connection, is not ready (%s)",
+			qb_util_log(LOG_INFO, "IPC connection not ready (%s)",
 				    c->description);
 		} else {
-			errno = -res;
-			qb_util_perror(LOG_ERR,
-				       "Error in connection setup (%s)",
+			qb_util_perror(LOG_INFO, "IPC connection setup failed (%s)",
 				       c->description);
+			errno = -res;
 		}
 
 		if (c->state == QB_IPCS_CONNECTION_INACTIVE) {

--- a/lib/ipcc.c
+++ b/lib/ipcc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010 Red Hat, Inc.
+ * Copyright 2010-2024 Red Hat, Inc.
  *
  * Author: Angus Salkeld <asalkeld@redhat.com>
  *
@@ -480,7 +480,7 @@ qb_ipcc_disconnect(struct qb_ipcc_connection *c)
 {
 	struct qb_ipc_one_way *ow = NULL;
 
-	qb_util_log(LOG_DEBUG, "%s()", __func__);
+	qb_util_log(LOG_TRACE, "%s(%s)", __func__, (c == NULL)? "NULL" : "");
 
 	if (c == NULL) {
 		return;

--- a/lib/ringbuffer.c
+++ b/lib/ringbuffer.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2011 Red Hat, Inc.
+ * Copyright 2010-2024 Red Hat, Inc.
  *
  * Author: Angus Salkeld <asalkeld@redhat.com>
  *
@@ -233,7 +233,7 @@ qb_rb_open_2(const char *name, size_t size, uint32_t flags,
 		goto cleanup_hdr;
 	}
 
-	qb_util_log(LOG_DEBUG,
+	qb_util_log(LOG_TRACE,
 		    "shm size:%ld; real_size:%ld; rb->word_size:%d", size,
 		    real_size, rb->shared_hdr->word_size);
 

--- a/lib/ringbuffer_helper.c
+++ b/lib/ringbuffer_helper.c
@@ -334,12 +334,12 @@ qb_rb_close_helper(struct qb_ringbuffer_s * rb, int32_t unlink_it,
 	char *hdr_path = rb->shared_hdr->hdr_path;
 
 	if (unlink_it) {
-		qb_util_log(LOG_DEBUG, "Free'ing ringbuffer: %s", hdr_path);
+		qb_util_log(LOG_TRACE, "Free'ing ringbuffer: %s", hdr_path);
 		if (rb->notifier.destroy_fn) {
 			(void)rb->notifier.destroy_fn(rb->notifier.instance);
 		}
 	} else {
-		qb_util_log(LOG_DEBUG, "Closing ringbuffer: %s", hdr_path);
+		qb_util_log(LOG_TRACE, "Closing ringbuffer: %s", hdr_path);
 		hdr_path = NULL;
 	}
 


### PR DESCRIPTION
When trying to open an IPC connection, log at info level rather than warning or error, because the caller has better context to know whether it's a problem or not. Users get distracted by error logs that don't actually indicate a problem.

Also lower some spammy messages to trace level.