### PR TITLE
Add support for LoongArch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -353,6 +353,11 @@ case $host_cpu in
 		AC_DEFINE_UNQUOTED([QB_ARCH_MIPS], [1], [mips])
 		arch_force_shmlba=yes
 		;;
+	loongson*)
+		AC_MSG_RESULT([loongson])
+		AC_DEFINE_UNQUOTED([QB_ARCH_LOONGSON], [1], [loongson])
+		arch_force_shmlba=yes
+		;;
 	*)
 		AC_MSG_RESULT([${host_cpu}])
 		;;

--- a/lib/unix.c
+++ b/lib/unix.c
@@ -229,7 +229,7 @@ qb_sys_circular_mmap(int32_t fd, void **buf, size_t bytes)
 	flags |= MAP_PRIVATE;
 #endif /* QB_FORCE_SHM_ALIGN */
 
-#if defined(QB_ARCH_HPPA)
+#if defined(QB_ARCH_HPPA) || defined(QB_ARCH_LOONGSON)
 	/* map twice the size we want to make sure we have already mapped
 	   the second memory location behind it too. Otherwise the Linux
 	   kernel may map it in the upper memory so that we can't map


### PR DESCRIPTION
This commit is adding support for LoongArch architecture.

The LoongArch architecture (LoongArch) is an Instruction Set Architecture (ISA) that has a RISC style.
Documentations:
ISA:
https://loongson.github.io/LoongArch-Documentation/LoongArch-Vol1-EN.html
ABI:
https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
More docs can be found at:
https://loongson.github.io/LoongArch-Documentation/README-EN.html