### PR TITLE
Fix a lot of annoying warning compiling with clang.

### DIFF
--- a/include/qb/qblist.h
+++ b/include/qb/qblist.h
@@ -195,7 +195,7 @@ static inline void qb_list_splice_tail(struct qb_list_head *list,
  * @param member:	the name of the list_struct within the struct.
  */
 #define qb_list_entry(ptr,type,member) ({	       \
-	((type *)((char*)ptr - offsetof(type, member))); })
+       ((type *)(void*)((char*)ptr - offsetof(type, member))); })
 
 /**
  * Get the first element from a list

--- a/tests/check_array.c
+++ b/tests/check_array.c
@@ -140,10 +140,10 @@ static Suite *array_suite(void)
 	TCase *tc;
 	Suite *s = suite_create("qb_array");
 
-	add_tcase(s, tc, test_array_limits);
-	add_tcase(s, tc, test_array_alloc_free);
-	add_tcase(s, tc, test_array_correct_retrieval);
-	add_tcase(s, tc, test_array_static_memory);
+	add_tcase(s, tc, test_array_limits, 0);
+	add_tcase(s, tc, test_array_alloc_free, 0);
+	add_tcase(s, tc, test_array_correct_retrieval, 0);
+	add_tcase(s, tc, test_array_static_memory, 0);
 
 	return s;
 }

--- a/tests/check_common.h
+++ b/tests/check_common.h
@@ -26,44 +26,18 @@
 
 #include <check.h>
 
-/*
-    Auxiliary macros
- */
+#define _STRINGIFY(arg)                #arg
+#define STRINGIFY(arg)         _STRINGIFY(arg)
 
-#define JOIN(a, b)		a##b
-#define _STRINGIFY(arg)		#arg
-#define STRINGIFY(arg)		_STRINGIFY(arg)
-
-/* wide-spread technique, see, e.g.,
-   http://cplusplus.co.il/2010/07/17/variadic-macro-to-count-number-of-arguments
- */
-#define VA_ARGS_CNT(...)	VA_ARGS_CNT_IMPL(__VA_ARGS__,8,7,6,5,4,3,2,1,_)
-#define VA_ARGS_CNT_IMPL(_1,_2,_3,_4,_5,_6,_7,_8,N,...)		N
-
-/* add_tcase "overloading" per argument count;
-   "func" argument is assumed to always starts with "test_", which is skipped
-   for the purpose of naming the respective test case that's being created */
-
-#define add_tcase_select(cnt)	JOIN(add_tcase_, cnt)
-#define add_tcase_3(suite, tcase, func) \
+#define add_tcase(suite, tcase, func, timeout) \
 	do { \
-		(tcase) = tcase_create(STRINGIFY(func) + sizeof("test")); \
+		const char * fname = STRINGIFY(func); \
+		(tcase) = tcase_create(fname + sizeof("test") ); \
 		tcase_add_test((tcase), func); \
+		if (timeout != 0) { \
+			tcase_set_timeout((tcase), (timeout));	\
+		} \
 		suite_add_tcase((suite), (tcase)); \
 	} while (0)
-#define add_tcase_4(suite, tcase, func, timeout) \
-	do { \
-		(tcase) = tcase_create(STRINGIFY(func) + sizeof("test")); \
-		tcase_add_test((tcase), func); \
-		tcase_set_timeout((tcase), (timeout)); \
-		suite_add_tcase((suite), (tcase)); \
-	} while (0)
-
-/*
-    Use-me macros
- */
-
-/* add_tcase(<dest-suite>, <testcase-tmp-storage>, <function>[, <timeout>]) */
-#define add_tcase(...)	add_tcase_select(VA_ARGS_CNT(__VA_ARGS__))(__VA_ARGS__)
 
 #endif

--- a/tests/check_ipc.c
+++ b/tests/check_ipc.c
@@ -64,12 +64,12 @@ static int CALCULATED_DGRAM_MAX_MSG_SIZE = 0;
    'variable length array in structure' extension will never be supported;
    assign default for SHM as we'll skip test that would use run-time
    established value (via qb_ipcc_verify_dgram_max_msg_size), anyway */
-static const int MAX_MSG_SIZE = DEFAULT_MAX_MSG_SIZE;
+#define MAX_MSG_SIZE  DEFAULT_MAX_MSG_SIZE
 #endif
 
 /* The size the giant msg's data field needs to be to make
  * this the largests msg we can successfully send. */
-#define GIANT_MSG_DATA_SIZE MAX_MSG_SIZE - sizeof(struct qb_ipc_response_header) - 8
+#define GIANT_MSG_DATA_SIZE (MAX_MSG_SIZE - sizeof(struct qb_ipc_response_header) - 8)
 
 static int enforce_server_buffer;
 static qb_ipcc_connection_t *conn;

--- a/tests/check_list.c
+++ b/tests/check_list.c
@@ -81,7 +81,7 @@ static Suite *array_suite(void)
 	TCase *tc;
 	Suite *s = suite_create("qb_list");
 
-	add_tcase(s, tc, test_list_iter);
+	add_tcase(s, tc, test_list_iter, 0);
 
 	return s;
 }

--- a/tests/check_log.c
+++ b/tests/check_log.c
@@ -1093,31 +1093,31 @@ log_suite(void)
 	TCase *tc;
 	Suite *s = suite_create("logging");
 
-	add_tcase(s, tc, test_va_serialize);
-	add_tcase(s, tc, test_log_stupid_inputs);
-	add_tcase(s, tc, test_log_basic);
-	add_tcase(s, tc, test_log_format);
-	add_tcase(s, tc, test_log_enable);
+	add_tcase(s, tc, test_va_serialize, 0);
+	add_tcase(s, tc, test_log_stupid_inputs, 0);
+	add_tcase(s, tc, test_log_basic, 0);
+	add_tcase(s, tc, test_log_format, 0);
+	add_tcase(s, tc, test_log_enable, 0);
 	add_tcase(s, tc, test_log_threads, 360);
-	add_tcase(s, tc, test_log_long_msg);
-	add_tcase(s, tc, test_log_filter_fn);
-	add_tcase(s, tc, test_threaded_logging);
-	add_tcase(s, tc, test_line_length);
-	add_tcase(s, tc, test_file_logging);
+	add_tcase(s, tc, test_log_long_msg, 0);
+	add_tcase(s, tc, test_log_filter_fn, 0);
+	add_tcase(s, tc, test_threaded_logging, 0);
+	add_tcase(s, tc, test_line_length, 0);
+	add_tcase(s, tc, test_file_logging, 0);
 #ifdef HAVE_PTHREAD_SETSCHEDPARAM
-	add_tcase(s, tc, test_threaded_logging_bad_sched_params);
+	add_tcase(s, tc, test_threaded_logging_bad_sched_params, 0);
 #endif
-	add_tcase(s, tc, test_timestamps);
-	add_tcase(s, tc, test_extended_information);
-	add_tcase(s, tc, test_zero_tags);
+	add_tcase(s, tc, test_timestamps, 0);
+	add_tcase(s, tc, test_extended_information, 0);
+	add_tcase(s, tc, test_zero_tags, 0);
 /*
  * You can still use syslog and journal in a normal application,
  * but the syslog_override code doesn't work when -lsystemd is present
  */
 #ifdef USE_JOURNAL
-        add_tcase(s, tc, test_journal);
+        add_tcase(s, tc, test_journal, 0);
 #else
-	add_tcase(s, tc, test_syslog);
+	add_tcase(s, tc, test_syslog, 0);
 #endif
 
 	return s;

--- a/tests/check_loop.c
+++ b/tests/check_loop.c
@@ -332,13 +332,13 @@ static Suite *loop_job_suite(void)
 	TCase *tc;
 	Suite *s = suite_create("loop_job");
 
-	add_tcase(s, tc, test_loop_job_input);
-	add_tcase(s, tc, test_loop_job_1);
-	add_tcase(s, tc, test_loop_job_4);
+	add_tcase(s, tc, test_loop_job_input, 0);
+	add_tcase(s, tc, test_loop_job_1, 0);
+	add_tcase(s, tc, test_loop_job_4, 0);
 	add_tcase(s, tc, test_loop_job_nuts, 5);
 	add_tcase(s, tc, test_job_rate_limit, 5);
-	add_tcase(s, tc, test_job_add_del);
-	add_tcase(s, tc, test_loop_job_order);
+	add_tcase(s, tc, test_job_add_del, 0);
+	add_tcase(s, tc, test_loop_job_order, 0);
 
 	return s;
 }
@@ -788,7 +788,7 @@ loop_timer_suite(void)
 	TCase *tc;
 	Suite *s = suite_create("loop_timers");
 
-	add_tcase(s, tc, test_loop_timer_input);
+	add_tcase(s, tc, test_loop_timer_input, 0);
 	add_tcase(s, tc, test_loop_timer_basic, 30);
 	add_tcase(s, tc, test_loop_timer_precision, 30);
 	add_tcase(s, tc, test_loop_timer_expire_leak, 30);
@@ -804,9 +804,9 @@ loop_signal_suite(void)
 	Suite *s = suite_create("loop_signal_suite");
 
 	add_tcase(s, tc, test_loop_sig_handling, 10);
-	add_tcase(s, tc, test_loop_sig_only_get_one);
-	add_tcase(s, tc, test_loop_sig_delete);
-	add_tcase(s, tc, test_loop_dont_override_other_signals);
+	add_tcase(s, tc, test_loop_sig_only_get_one, 0);
+	add_tcase(s, tc, test_loop_sig_delete, 0);
+	add_tcase(s, tc, test_loop_dont_override_other_signals, 0);
 
 	return s;
 }

--- a/tests/check_map.c
+++ b/tests/check_map.c
@@ -992,32 +992,32 @@ map_suite(void)
 	TCase *tc;
 	Suite *s = suite_create("qb_map");
 
-	add_tcase(s, tc, test_skiplist_simple);
-	add_tcase(s, tc, test_hashtable_simple);
-	add_tcase(s, tc, test_trie_simple);
-	add_tcase(s, tc, test_trie_partial_iterate);
-	add_tcase(s, tc, test_skiplist_remove);
-	add_tcase(s, tc, test_hashtable_remove);
-	add_tcase(s, tc, test_trie_notifications);
-	add_tcase(s, tc, test_hash_notifications);
-	add_tcase(s, tc, test_skiplist_notifications);
-	add_tcase(s, tc, test_skiplist_search);
+	add_tcase(s, tc, test_skiplist_simple, 0);
+	add_tcase(s, tc, test_hashtable_simple, 0);
+	add_tcase(s, tc, test_trie_simple, 0);
+	add_tcase(s, tc, test_trie_partial_iterate, 0);
+	add_tcase(s, tc, test_skiplist_remove, 0);
+	add_tcase(s, tc, test_hashtable_remove, 0);
+	add_tcase(s, tc, test_trie_notifications, 0);
+	add_tcase(s, tc, test_hash_notifications, 0);
+	add_tcase(s, tc, test_skiplist_notifications, 0);
+	add_tcase(s, tc, test_skiplist_search, 0);
 
 /*
  * 	No hashtable_search as it assumes an ordered
  *	collection
  */
-	add_tcase(s, tc, test_trie_search);
-	add_tcase(s, tc, test_skiplist_traverse);
-	add_tcase(s, tc, test_hashtable_traverse);
-	add_tcase(s, tc, test_trie_traverse);
+	add_tcase(s, tc, test_trie_search, 0);
+	add_tcase(s, tc, test_skiplist_traverse, 0);
+	add_tcase(s, tc, test_hashtable_traverse, 0);
+	add_tcase(s, tc, test_trie_traverse, 0);
 	add_tcase(s, tc, test_skiplist_load, 30);
 	add_tcase(s, tc, test_hashtable_load, 30);
 	add_tcase(s, tc, test_trie_load, 30);
 
-	add_tcase(s, tc, test_skiplist_accents);
-	add_tcase(s, tc, test_hashtable_accents);
-	add_tcase(s, tc, test_trie_accents);
+	add_tcase(s, tc, test_skiplist_accents, 0);
+	add_tcase(s, tc, test_hashtable_accents, 0);
+	add_tcase(s, tc, test_trie_accents, 0);
 
 	return s;
 }

--- a/tests/check_rb.c
+++ b/tests/check_rb.c
@@ -195,10 +195,10 @@ static Suite *rb_suite(void)
 	TCase *tc;
 	Suite *s = suite_create("ringbuffer");
 
-	add_tcase(s, tc, test_ring_buffer1);
-	add_tcase(s, tc, test_ring_buffer2);
-	add_tcase(s, tc, test_ring_buffer3);
-	add_tcase(s, tc, test_ring_buffer4);
+	add_tcase(s, tc, test_ring_buffer1, 0);
+	add_tcase(s, tc, test_ring_buffer2, 0);
+	add_tcase(s, tc, test_ring_buffer3, 0);
+	add_tcase(s, tc, test_ring_buffer4, 0);
 
 	return s;
 }

--- a/tests/check_tlist.c
+++ b/tests/check_tlist.c
@@ -266,7 +266,7 @@ static Suite *tlist_suite(void)
 	TCase *tc;
 	Suite *s = suite_create("tlist");
 
-	add_tcase(s, tc, test_check_basic);
+	add_tcase(s, tc, test_check_basic, 0);
 	add_tcase(s, tc, test_check_speed, 30);
 	add_tcase(s, tc, test_check_heap, 30);
 

--- a/tests/check_util.c
+++ b/tests/check_util.c
@@ -160,8 +160,8 @@ static Suite *util_suite(void)
 	TCase *tc;
 	Suite *s = suite_create("qb_util");
 
-	add_tcase(s, tc, test_check_overwrite);
-	add_tcase(s, tc, test_check_normal);
+	add_tcase(s, tc, test_check_overwrite, 0);
+	add_tcase(s, tc, test_check_normal, 0);
 
 	return s;
 }


### PR DESCRIPTION
Also remove the really crazy macros used for defining the tests which were hard to read and totally unnecessary