### PR TITLE
Silence warnings, ignore *.fdata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ test-driver
 /tests/functional/**/log_interlib_client
 /tests/functional/_pkgs
 /tests/functional/_results
+
+# blackbox data dumps from tests/examples
+*.fdata

--- a/configure.ac
+++ b/configure.ac
@@ -223,6 +223,7 @@ AC_TYPE_UINT32_T
 AC_TYPE_UINT16_T
 AC_TYPE_UINT8_T
 
+AC_CHECK_DECLS_ONCE([[__xstat]], [], [], [[#include <sys/stat.h>]])
 AC_CHECK_MEMBER([struct sockaddr_un.sun_len],
                 [AC_DEFINE([HAVE_STRUCT_SOCKADDR_UN_SUN_LEN],
                            1,

--- a/docs/man.dox.in
+++ b/docs/man.dox.in
@@ -1365,14 +1365,9 @@ SKIP_FUNCTION_MACROS   = NO
 # Configuration options related to the dot tool
 #---------------------------------------------------------------------------
 
-# If the CLASS_DIAGRAMS tag is set to YES, doxygen will generate a class diagram
-# (in HTML and LaTeX) for classes with base or super classes. Setting the tag to
-# NO turns the diagrams off. Note that this option also works with HAVE_DOT
-# disabled, but it is recommended to install and use dot, since it yields more
-# powerful graphs.
-# The default value is: YES.
+# Disable generation of class inheritance diagrams.
 
-CLASS_DIAGRAMS         = NO
+CLASS_GRAPH            = NO
 
 # If set to YES the inheritance and collaboration graphs will hide inheritance
 # and usage relations if the target is undocumented or is not a class.

--- a/doxygen2man/cstring.c
+++ b/doxygen2man/cstring.c
@@ -26,17 +26,16 @@ struct cstring_header
 
 cstring_t cstring_alloc(void)
 {
-	char *cstring = malloc(INITIAL_SIZE);
-	if (cstring) {
-		struct cstring_header *h = (struct cstring_header *)cstring;
-		h->checker = CHECKER_WORD;
-		h->allocated = INITIAL_SIZE;
-		h->used = 0;
-		h->the_string[0] = '\0';
-		return cstring;
-	} else {
+	struct cstring_header *cstring = malloc(INITIAL_SIZE);
+
+	if (cstring == NULL)
 		return NULL;
-	}
+
+	cstring->checker = CHECKER_WORD;
+	cstring->allocated = INITIAL_SIZE;
+	cstring->used = 0;
+	cstring->the_string[0] = '\0';
+	return cstring;
 }
 
 char *cstring_to_chars(cstring_t cstring)

--- a/examples/simplelog.c
+++ b/examples/simplelog.c
@@ -248,8 +248,8 @@ main(int32_t argc, char *argv[])
 	}
 
 	if (do_blackbox) {
-		logfile = NULL;
-		logfile[5] = 'a';
+		/* Emulate a bug to exercise the signal handler */
+		*(volatile int *)0 = 1;
 	} else {
 		qb_log_fini();
 	}

--- a/tests/_libstat_wrapper.c
+++ b/tests/_libstat_wrapper.c
@@ -8,8 +8,13 @@
 #include <sys/stat.h>
 #include "../include/config.h"
 
+#if !HAVE_DECL___XSTAT
+#define XSTATIC __attribute__((used)) static
+#else
+#define XSTATIC
+#endif
 // __xstat for earlier libc
-int __xstat(int __ver, const char *__filename, struct stat *__stat_buf)
+XSTATIC int __xstat(int __ver, const char *__filename, struct stat *__stat_buf)
 {
 #if defined(QB_LINUX) || defined(QB_CYGWIN)
 	static int opened = 0;

--- a/tests/check_map.c
+++ b/tests/check_map.c
@@ -500,7 +500,7 @@ test_map_traverse_ordered(qb_map_t *m)
 	for (i = 0; chars[i]; i++) {
 		qb_map_put(m, chars[i], chars[i]);
 	}
-	result = calloc(sizeof(char), 26 * 2 + 10 + 1);
+	result = calloc(26 * 2 + 10 + 1, sizeof(char));
 
 	i = 0;
 	for (p = qb_map_iter_next(it, &data); p; p = qb_map_iter_next(it, &data)) {

--- a/tests/crash_test_dummy.c
+++ b/tests/crash_test_dummy.c
@@ -72,7 +72,6 @@ sigsegv_handler(int sig)
 int32_t
 main(int32_t argc, char *argv[])
 {
-	char *logfile;
 	int i;
 
 	signal(SIGSEGV, sigsegv_handler);
@@ -100,9 +99,7 @@ main(int32_t argc, char *argv[])
 		func_two();
 	}
 
-	/* on purpose crash to make a blackbox.
-	 */
-       	logfile = NULL;
-	logfile[5] = 'a';
+	/* on purpose crash to make a blackbox. */
+	*(volatile int *)0 = 1;
 	return 0;
 }


### PR DESCRIPTION
Make -Werror more useful during development by cleaning up some warnings. See the commit logs for details.

Also add *.fdata to .gitignore as those files are generated by tests and examples.