### PR TITLE
doxygen2man: Fix segfault on anonymous enums

### DIFF
--- a/doxygen2man/doxygen2man.c
+++ b/doxygen2man/doxygen2man.c
@@ -1030,7 +1030,11 @@ static void collect_enums(xmlNode *cur_node, void *arg)
 
 			for (this_tag = cur_node->children; this_tag; this_tag = this_tag->next) {
 				if (this_tag->type == XML_ELEMENT_NODE && strcmp((char *)this_tag->name, "name") == 0) {
-					name = strdup((char *)this_tag->children->content);
+					if (this_tag->children)
+						name = strdup((char *)this_tag->children->content);
+					else
+						name = strdup("enum");
+					break;
 				}
 			}
 
@@ -1040,7 +1044,7 @@ static void collect_enums(xmlNode *cur_node, void *arg)
 					memset(si, 0, sizeof(*si));
 					si->kind = STRUCTINFO_ENUM;
 					qb_list_init(&si->params_list);
-					si->structname = strdup(name);
+					si->structname = name;
 					traverse_node(cur_node, "enumvalue", read_struct, si);
 					qb_map_put(structures_map, refid, si);
 				}


### PR DESCRIPTION
For these the "name" xml tag has a NULL children field. doxygen2man currently doesn't seem to output anything for enums so we can just check for the NULL pointer and use strdup("enum") as the name in that case.

You can test this easily by patching `enum { FOO };` into `include/qb/qbarray.h` or another header that doxygen2man processes the doxygen xml for, and then running `make`.

I guess this might need some iteration if doxygen2man should be outputting something for enums.

~~There's also a second `strdup(name)` at https://github.com/ClusterLabs/libqb/blob/main/doxygen2man/doxygen2man.c#L1043 which can probably be removed since the name was already `strdup()`ed. But first thing's first :)~~ The latest static analysis in CI failed on that strdup so I've removed it.