### PR TITLE
strchr() const correctness fixes

### DIFF
--- a/lib/ipc_setup.c
+++ b/lib/ipc_setup.c
@@ -963,7 +963,7 @@ void remove_tempdir(const char *name)
 {
 #if defined(QB_LINUX) || defined(QB_CYGWIN)
 	char dirname[PATH_MAX];
-	char *slash = strrchr(name, '/');
+	const char *slash = strrchr(name, '/');
 
 	if (slash && slash - name < sizeof dirname) {
 		memcpy(dirname, name, slash - name);

--- a/lib/log.c
+++ b/lib/log.c
@@ -301,7 +301,7 @@ qb_log_real_(struct qb_log_callsite *cs, ...)
 
 void
 qb_log_thread_log_write(struct qb_log_callsite *cs,
-			struct timespec *timestamp, const char *buffer)
+			struct timespec *timestamp, char *buffer)
 {
 	struct qb_log_target *t;
 	enum qb_log_target_slot pos;

--- a/lib/log_int.h
+++ b/lib/log_int.h
@@ -118,7 +118,7 @@ void qb_log_thread_log_post(struct qb_log_callsite *cs,
 			    const char *buffer);
 void qb_log_thread_log_write(struct qb_log_callsite *cs,
 			    struct timespec *current_time,
-			    const char *buffer);
+			    char *buffer);
 void qb_log_thread_pause(struct qb_log_target *t);
 void qb_log_thread_resume(struct qb_log_target *t);
 

--- a/lib/unix.c
+++ b/lib/unix.c
@@ -118,7 +118,7 @@ qb_sys_mmap_file_open(char *path, const char *file, size_t bytes,
 	char *buffer = NULL;
 	int32_t i;
 #endif
-	char *is_absolute = strchr(file, '/');
+	const char *is_absolute = strchr(file, '/');
 #ifdef HAVE_POSIX_FALLOCATE
 	int32_t fallocate_retry = 5;
 #endif


### PR DESCRIPTION
Clang now warns when the variable storing the result of strchr() throws away the constness of the string passed into it.

For remove_tempdir() and qb_sys_mmap_file_open() the fix is a simple addition of const.

qb_log_thread_log_write() needs const removed from its buffer parameter as the qb_do_extended macro writes to it when handling the special extended logging marker. Luckily nothing passes a const buffer to the function so that's okay.